### PR TITLE
chore: agregar configuracion de clang-format y .editorconfig Closes #84

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,5 @@
-BasedOnStyle: LLVM
-IndentWidth: 2
+BasedOnStyle: Google
+IndentWidth: 4
+ColumnLimit: 100
+AccessModifierOffset: -2
+AllowShortFunctionsOnASingleLine: Inline

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.{cpp,hpp,h,cmake,txt,md}]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
## ¿Qué hace este PR?

Se han agregado los archivos de configuración `.clang-format` y `.editorconfig` en la raíz del proyecto para estandarizar el formato del código y las reglas del editor de texto, cumpliendo con los requerimientos técnicos.

## Issue relacionado

Closes #84

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="623" height="337" alt="image" src="https://github.com/user-attachments/assets/7afddd1f-a3d3-4b09-9762-73605edc729d" />
