### PR TITLE
feat: crear formateador de salida a consola #31

### DIFF
--- a/src/utils/console_formatter.cpp
+++ b/src/utils/console_formatter.cpp
@@ -1,0 +1,13 @@
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <string>
+
+void printMetrics(const std::map<std::string, double>& data) {
+    for (const auto& entry : data) {
+        if (entry.second >= 0) {
+            std::cout << std::left << std::setw(6) << entry.first + ":"
+                      << std::setw(8) << entry.second << "%" << std::endl;
+        }
+    }
+}

--- a/src/utils/disk_usage.cpp
+++ b/src/utils/disk_usage.cpp
@@ -1,0 +1,14 @@
+#include <sys/statvfs.h>
+
+double getDiskUsage() {
+    struct statvfs stat;
+
+    if (statvfs("/", &stat) != 0) {
+        return -1.0;
+    }
+
+    unsigned long blocks = stat.f_blocks;
+    unsigned long bfree  = stat.f_bfree;
+
+    return (double)(blocks - bfree) / blocks * 100;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la función printMetrics() en src/utils/console_formatter.cpp 
que imprime métricas alineadas en consola usando std::setw y std::left.
Solo imprime valores >= 0.

## Issue relacionado
Closes #31

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="616" height="270" alt="image" src="https://github.com/user-attachments/assets/45530ff1-adaa-4b52-a7a2-9b00ca47a339" />
