### PR TITLE
feat: añadir manejo de señal SIGINT para salida limpia #35

### DIFF
--- a/src/utils/signal_handler.cpp
+++ b/src/utils/signal_handler.cpp
@@ -1,0 +1,13 @@
+#include <csignal>
+#include <iostream>
+
+bool isRunning = true;
+
+void handler(int signal) {
+    isRunning = false;
+    std::cout << "\nMonitor detenido." << std::endl;
+}
+
+void setupSignalHandler() {
+    signal(SIGINT, handler);
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el manejo de la señal SIGINT (Ctrl+C) en src/utils/signal_handler.cpp.
El handler setea isRunning = false, imprime "Monitor detenido." 
y permite liberar recursos antes de salir.

## Issue relacionado
Closes #35

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="484" height="256" alt="image" src="https://github.com/user-attachments/assets/a1b9b48e-010c-45a4-9d4c-e95f05889b51" />
