### PR TITLE
feat: implementar lectura de red desde /proc/net/dev #37

### DIFF
--- a/src/collectors/network/network_io.cpp
+++ b/src/collectors/network/network_io.cpp
@@ -1,0 +1,35 @@
+#include <fstream>
+#include <sstream>
+#include <string>
+
+struct NetworkIO {
+    long rx;
+    long tx;
+};
+
+NetworkIO getNetworkIO() {
+   
+    NetworkIO result = {-1, -1};
+    std::ifstream file("/proc/net/dev");
+    std::string line;
+
+    while (std::getline(file, line)) {
+        if (line.find("eth0") != std::string::npos ||
+            line.find("wlan0") != std::string::npos) {
+
+            std::istringstream ss(line);
+            std::string iface;
+            long rx, tx;
+            long skip;
+
+            ss >> iface >> rx;
+            for (int i = 0; i < 7; i++) ss >> skip;
+            ss >> tx;
+
+            result.rx = rx;
+            result.tx = tx;
+            return result;
+        }
+    }
+    return result;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la función getNetworkIO() en src/collectors/network_io.cpp
que obtiene bytes recibidos (rx) y enviados (tx) de eth0 o wlan0
parseando /proc/net/dev columnas 1 y 9.
Retorna -1 si la interfaz no existe.


## Issue relacionado
Closes #37

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="486" height="603" alt="image" src="https://github.com/user-attachments/assets/db50a895-6c5a-456d-941a-c2d371a7bc4d" />
