### PR TITLE
feat(formatters): definir interfaz abstracta IFormatter #87

### DIFF
--- a/src/formatters/iformatter.hpp
+++ b/src/formatters/iformatter.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include "core/snapshot.hpp"
+
+namespace pulso::formatters {
+
+/**
+ * @brief Interfaz abstracta para los formateadores de métricas.
+ *
+ * Define el contrato que deben cumplir todos los formateadores
+ * del sistema Pulso. Cada implementación serializa un Snapshot
+ * en un formato específico (JSON, Prometheus, etc.).
+ */
+class IFormatter {
+public:
+    /**
+     * @brief Destructor virtual por defecto.
+     */
+    virtual ~IFormatter() = default;
+
+    /**
+     * @brief Retorna el identificador del formato.
+     * @return Ejemplo: "json", "prometheus"
+     */
+    virtual std::string formato() const = 0;
+
+    /**
+     * @brief Retorna el Content-Type HTTP asociado al formato.
+     * @return Ejemplo: "application/json", "text/plain"
+     */
+    virtual std::string contentType() const = 0;
+
+    /**
+     * @brief Serializa un único snapshot de métricas.
+     * @param snapshot El snapshot a serializar.
+     * @return Cadena con el snapshot en el formato correspondiente.
+     */
+    virtual std::string formatear(const pulso::core::Snapshot& snapshot) const = 0;
+
+    /**
+     * @brief Serializa una lista de snapshots (historial).
+     * @param snapshots Vector de snapshots a serializar.
+     * @return Cadena con el historial en el formato correspondiente.
+     */
+    virtual std::string formatearHistorial(
+        const std::vector<pulso::core::Snapshot>& snapshots) const = 0;
+};
+
+} // namespace pulso::formatters


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea src/formatters/iformatter.hpp con la clase abstracta IFormatter
dentro del namespace pulso::formatters. Define 4 métodos virtuales puros:
formato(), contentType(), formatear() y formatearHistorial().
Cada método está documentado con Doxygen.


## Issue relacionado
Closes #87

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica