### PR TITLE
feat: implementar loop de monitoreo con sleep - Closes#33

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,1 +1,61 @@
-int main() { return 0; }
+#include <atomic>
+#include <chrono>
+#include <map>
+#include <string>
+#include <thread>
+
+// --- Declaraciones de funciones existentes en otros archivos ---
+
+// collectors/cpu/cpu_usage.cpp
+double ObtenerUsoCPU();
+
+// utils/disk_usage.cpp
+double getDiskUsage();
+
+// collectors/network/network_io.cpp
+struct NetworkIO { long rx; long tx; };
+NetworkIO getNetworkIO();
+
+// utils/console_formatter.cpp
+void printMetrics(const std::map<std::string, double>& data);
+
+// utils/signal_handler.cpp
+void setupSignalHandler();
+extern std::atomic<bool> isRunning;
+
+// --------------------------------------------------------------
+
+/**
+ * @brief Ejecuta el loop de monitoreo hasta que isRunning sea false.
+ *
+ * En cada iteración:
+ *  1. Recolecta métricas de CPU, disco y red en un mapa.
+ *  2. Llama al formateador para mostrarlas por consola.
+ *  3. Duerme `intervalo_ms` milisegundos antes del siguiente ciclo.
+ *
+ * @param intervalo_ms Tiempo de espera entre lecturas, en milisegundos.
+ */
+void start(int intervalo_ms) {
+    while (isRunning) {
+        // 1. Actualizar el mapa con las lecturas de cada collector
+        std::map<std::string, double> metricas;
+        metricas["cpu"]    = ObtenerUsoCPU();
+        metricas["disk"]   = getDiskUsage();
+
+        NetworkIO net      = getNetworkIO();
+        metricas["net.rx"] = static_cast<double>(net.rx);
+        metricas["net.tx"] = static_cast<double>(net.tx);
+
+        // 2. Llamar al formateador
+        printMetrics(metricas);
+
+        // 3. Esperar X ms antes del siguiente ciclo
+        std::this_thread::sleep_for(std::chrono::milliseconds(intervalo_ms));
+    }
+}
+
+int main() {
+    setupSignalHandler();
+    start(1000);  // lectura cada 1000 ms
+    return 0;
+}

--- a/src/utils/signal_handler.cpp
+++ b/src/utils/signal_handler.cpp
@@ -1,7 +1,8 @@
 #include <csignal>
+#include <atomic>
 #include <iostream>
 
-bool isRunning = true;
+std::atomic<bool> isRunning = true;
 
 void handler(int signal) {
     isRunning = false;


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el loop de monitoreo continuo en `start()` dentro de `main.cpp`. En cada ciclo se recolectan métricas de CPU, disco y red en un mapa, se llama al formateador para mostrarlas por consola, y se espera el intervalo configurado antes de repetir. El loop se detiene de forma segura cuando `isRunning` pasa a `false` al recibir la señal `SIGINT` (Ctrl+C).

También se actualiza `signal_handler.cpp` para declarar `isRunning` como `std::atomic<bool>`, requisito necesario para que el flag pueda ser modificado desde el hilo de señales sin condiciones de carrera.

## Issue relacionado
Closes #33

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde