### PR TITLE
docs: Completar docs/instalacion.md con guía de instalación paso a paso - Closes#46

### DIFF
--- a/docs/instalacion.md
+++ b/docs/instalacion.md
@@ -8,10 +8,31 @@ Este documento describe los pasos necesarios para instalar y ejecutar Pulso en u
 
 Antes de instalar Pulso, asegúrese de contar con lo siguiente:
 
-- Sistema operativo Linux
-- Compilador compatible con C++
-- Git instalado
-- CMake instalado
+| Requisito | Versión mínima | Notas |
+|---|---|---|
+| Sistema operativo | — | Linux, Windows o macOS |
+| Compilador C++ | C++17 | GCC, Clang o MSVC |
+| CMake | 3.16 | |
+| Git | — | Para clonar el repositorio |
+
+### Instalar dependencias
+ 
+**Linux (Debian/Ubuntu)**
+```bash
+sudo apt install g++ cmake git
+```
+ 
+**macOS**
+```bash
+brew install cmake git
+```
+> El compilador Clang viene incluido con las herramientas de línea de comandos de Xcode. Si no lo tiene, ejecute `xcode-select --install`.
+ 
+**Windows**
+ 
+- Instale [CMake](https://cmake.org/download/) y marque la opción para agregarlo al PATH durante la instalación.
+- Instale [Git](https://git-scm.com/download/win).
+- Instale [Visual Studio](https://visualstudio.microsoft.com/) con la carga de trabajo **"Desarrollo de escritorio con C++"**, que incluye el compilador MSVC.
 
 ---
 
@@ -21,3 +42,60 @@ Ejecute el siguiente comando para clonar el proyecto:
 
 ```bash
 git clone https://github.com/sis-inf/pulso.git
+cd pulso
+```
+
+---
+
+## Compilar el proyecto
+ 
+### Linux y macOS
+ 
+```bash
+# Configurar el proyecto y crear la carpeta build
+cmake -B build
+ 
+# Compilar
+cmake --build build
+```
+ 
+### Windows
+ 
+Abra el **Developer Command Prompt** de Visual Studio y ejecute:
+ 
+```bash
+# Configurar el proyecto y crear la carpeta build
+cmake -B build
+ 
+# Compilar
+cmake --build build --config Release
+```
+ 
+> El binario resultante se encuentra en `build/bin/`.
+ 
+---
+ 
+## Ejecutar el programa
+ 
+### Linux y macOS
+ 
+```bash
+./build/bin/pulso
+```
+ 
+### Windows
+ 
+```bash
+build\bin\Release\pulso.exe
+```
+ 
+---
+ 
+## Notas adicionales
+ 
+- En Linux, si aparecen errores de permisos al acceder a `/proc`, verifique que el usuario tenga los permisos necesarios. No se recomienda modificar permisos del sistema sin conocer su impacto.
+- Para compilar sin ejecutar los tests, agregue `-DPULSO_BUILD_TESTS=OFF` al comando de configuración:
+
+```bash
+cmake -B build -DPULSO_BUILD_TESTS=OFF
+```


### PR DESCRIPTION
## ¿Qué hace este PR?
Completa el archivo `docs/instalacion.md` con la guía de instalación paso a paso. El archivo existía pero estaba incompleto: solo cubría Linux y no incluía los pasos de compilación ni ejecución.

La guía ahora incluye:
- Tabla de requisitos previos con versiones mínimas (C++17, CMake 3.16, Git)
- Comandos de instalación de dependencias para Linux, macOS y Windows
- Pasos para clonar el repositorio
- Pasos para compilar con CMake diferenciados por plataforma
- Pasos para ejecutar el binario resultante en cada plataforma

## Issue relacionado
Closes #46

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas