### PR TITLE
chore: añadir flags de compilación seguros -Wall -Wextra -Wpedantic -…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# Flags de compilación seguros
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -O2")
+
 option(PULSO_BUILD_TESTS "Build tests" ON)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)


### PR DESCRIPTION
## ¿Qué hace este PR?
Añade flags de compilación seguros al `CMakeLists.txt` raíz del proyecto:

- `-Wall`: Habilita warnings comunes
- `-Wextra`: Habilita warnings adicionales
- `-Wpedantic`: Compilación estricta según estándar
- `-O2`: Optimización nivel 2

## Issue relacionado
Closes #39

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Compilación exitosa sin warnings:
mkdir -p build && cd build cmake .. -DPULSO_BUILD_TESTS=ON
-- Tests are enabled (PULSO_BUILD_TESTS=ON)
-- Configuring done (0.2s)
-- Generating done (0.0s)

$ make
[ 50%] Building CXX object src/CMakeFiles/pulso.dir/main.cpp.o
[100%] Linking CXX executable ../bin/pulso
[100%] Built target pulso