### PR TITLE
chore: configurar Makefile alternativo - Closes#34

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,60 @@
+# ==============================================================================
+# Makefile simple — Issue #34
+# Compilación sin CMake para entornos ligeros
+# ==============================================================================
+
+CXX     ?= g++
+CXXFLAGS = -std=c++17 -Wall
+
+SRC_DIR  = src
+TEST_DIR = tests
+BUILD_DIR = build
+
+# Recopilar fuentes automáticamente
+SRCS     = $(wildcard $(SRC_DIR)/*.cpp)
+OBJS     = $(patsubst $(SRC_DIR)/%.cpp, $(BUILD_DIR)/%.o, $(SRCS))
+
+TEST_SRCS = $(wildcard $(TEST_DIR)/*.cpp)
+TEST_OBJS = $(patsubst $(TEST_DIR)/%.cpp, $(BUILD_DIR)/test_%.o, $(TEST_SRCS))
+
+TARGET      = $(BUILD_DIR)/app
+TEST_TARGET = $(BUILD_DIR)/run_tests
+
+# ------------------------------------------------------------------------------
+# Target por defecto
+# ------------------------------------------------------------------------------
+.PHONY: all
+all: $(TARGET)
+
+$(TARGET): $(OBJS) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+# Compilar cada .cpp → .o solo si hubo cambios (regla implícita con prereqs)
+$(BUILD_DIR)/%.o: $(SRC_DIR)/%.cpp | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+# ------------------------------------------------------------------------------
+# Tests
+# ------------------------------------------------------------------------------
+.PHONY: test
+test: $(TEST_TARGET)
+	./$(TEST_TARGET)
+
+$(TEST_TARGET): $(TEST_OBJS) $(filter-out $(BUILD_DIR)/main.o, $(OBJS)) | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -o $@ $^
+
+$(BUILD_DIR)/test_%.o: $(TEST_DIR)/%.cpp | $(BUILD_DIR)
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+# ------------------------------------------------------------------------------
+# Directorio de build
+# ------------------------------------------------------------------------------
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# ------------------------------------------------------------------------------
+# Limpieza
+# ------------------------------------------------------------------------------
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)

--- a/README.md
+++ b/README.md
@@ -124,6 +124,62 @@ Red:
 > [!IMPORTANT]
 > Este proyecto se encuentra en desarrollo activo. Los pasos de instalación y ejecución pueden cambiar en futuras versiones.
 ---
+## Compilación con Makefile (sin CMake)
+ 
+Para entornos ligeros donde CMake no está disponible, el proyecto incluye un
+`Makefile` alternativo listo para usar.
+ 
+### Requisitos
+ 
+| Herramienta | Versión mínima |
+|-------------|---------------|
+| `g++` / `clang++` | C++17 |
+| GNU Make | 4.x |
+ 
+### Uso rápido
+ 
+```bash
+# Compilar el proyecto
+make
+ 
+# Usar un compilador distinto (ej. clang++)
+make CXX=clang++
+ 
+# Ejecutar los tests
+make test
+ 
+# Eliminar artefactos de compilación
+make clean
+```
+ 
+### Variables configurables
+ 
+| Variable | Valor por defecto | Descripción |
+|----------|------------------|-------------|
+| `CXX` | `g++` | Compilador C++ |
+| `CXXFLAGS` | `-std=c++17 -Wall` | Flags de compilación |
+ 
+> **Nota:** el operador `?=` en `CXX` permite sobreescribir el compilador
+> desde la línea de comandos o desde la variable de entorno del sistema sin
+> modificar el Makefile.
+ 
+### Estructura esperada
+ 
+```
+project/
+├── src/          # Fuentes principales (*.cpp)
+├── tests/        # Fuentes de pruebas  (*.cpp)
+├── build/        # Artefactos generados (ignorado por git)
+└── Makefile
+```
+ 
+### Recompilación incremental
+ 
+El Makefile compila únicamente los archivos `.cpp` que hayan cambiado desde
+la última build, gracias al seguimiento de dependencias de Make sobre los
+archivos objeto (`.o`) en `build/`.
+
+---
 
 ## Documentación
 Ver la carpeta [docs/](docs/)


### PR DESCRIPTION
## ¿Qué hace este PR?
Este Pull Request introduce un **Makefile alternativo** para entornos ligeros, evitando la dependencia de CMake.  
Se configuró la compilación básica con `g++` y banderas estándar, y se documentó su uso en el archivo `README.md`.

Se realizaron los siguientes cambios:
- Creación del archivo `Makefile` con reglas:
  - `all`: compilación principal  
  - `clean`: limpieza de binarios generados  
  - `test`: ejecución de pruebas  
- Configuración de variables:
  - `CXX ?= g++`  
  - `CXXFLAGS = -std=c++17 -Wall`  
- Documentación en `README.md` sobre cómo usar el Makefile.

## Issue relacionado
Closes #34

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde