### PR TITLE
feat: implementar CollectorNetwork - Closes #154

### DIFF
--- a/src/collectors/network/net_usage.cpp
+++ b/src/collectors/network/net_usage.cpp
@@ -1,0 +1,60 @@
+#include "net_usage.h"
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+/// @brief Obtiene los bytes recibidos y enviados por la red desde /proc/net/dev.
+/// Salta las dos primeras líneas de encabezado, parsea cada interfaz extrayendo
+/// el nombre (antes de ':'), columna 1 = rx_bytes y columna 9 = tx_bytes.
+/// Excluye la interfaz lo y suma el resto de interfaces.
+/// @param ruta Ruta al archivo de estadísticas de red.
+/// @return Estructura UsoRed con rx_bytes_total y tx_bytes_total.
+/// @throws std::runtime_error si el archivo no es accesible.
+UsoRed ObtenerUsoRed(const std::string& ruta) {
+    std::ifstream archivo(ruta);
+
+    if (!archivo.is_open()) {
+        throw std::runtime_error(
+            "Error al acceder a " + ruta + ": archivo no accesible"
+        );
+    }
+
+    UsoRed uso{};
+    std::string linea;
+
+    std::getline(archivo, linea); 
+    std::getline(archivo, linea); 
+
+    while (std::getline(archivo, linea)) {
+        std::istringstream flujo(linea);
+
+        std::string nombre_interfaz;
+        std::getline(flujo, nombre_interfaz, ':');
+
+        size_t inicio = nombre_interfaz.find_first_not_of(" \t");
+        if (inicio != std::string::npos) {
+            nombre_interfaz = nombre_interfaz.substr(inicio);
+        }
+
+        if (nombre_interfaz == "lo") {
+            continue;
+        }
+
+        uint64_t rx_bytes = 0;
+        uint64_t ignorado = 0;
+        uint64_t tx_bytes = 0;
+
+        flujo >> rx_bytes;  
+
+        for (int i = 0; i < 7; ++i) {
+            flujo >> ignorado;
+        }
+
+        flujo >> tx_bytes;    
+        uso.rx_bytes_total += rx_bytes;
+        uso.tx_bytes_total += tx_bytes;
+    }
+
+    return uso;
+}

--- a/src/collectors/network/net_usage.h
+++ b/src/collectors/network/net_usage.h
@@ -1,0 +1,23 @@
+#ifndef NET_USAGE_H
+#define NET_USAGE_H
+
+#include <cstdint>
+#include <string>
+
+/// @brief Estructura que representa el uso de red del sistema.
+/// Acumula los bytes recibidos y enviados de todas las interfaces
+/// activas, excluyendo la interfaz de loopback (lo).
+struct UsoRed {
+    uint64_t rx_bytes_total{}; ///< Total de bytes recibidos por todas las interfaces
+    uint64_t tx_bytes_total{}; ///< Total de bytes enviados por todas las interfaces
+};
+
+/// @brief Obtiene los bytes recibidos y enviados por la red.
+/// Lee /proc/net/dev, salta las dos primeras líneas de encabezado,
+/// parsea cada interfaz y excluye la interfaz lo.
+/// @param ruta Ruta al archivo (por defecto "/proc/net/dev").
+/// @return Estructura UsoRed con rx_bytes_total y tx_bytes_total.
+/// @throws std::runtime_error si el archivo no es accesible.
+UsoRed ObtenerUsoRed(const std::string& ruta = "/proc/net/dev");
+
+#endif 


### PR DESCRIPTION
## ¿Qué hace este PR?
Se ha implementado el componente `CollectorNetwork` encargado de medir el tráfico de red (bytes recibidos y transmitidos) en sistemas, mediante la lectura del archivo de sistema `/proc/net/dev`.

## Issue relacionado
Closes #154 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="725" height="344" alt="image" src="https://github.com/user-attachments/assets/9f9ba615-dc3a-487d-9a27-f9feeb8d95fa" />
