### PR TITLE
feat(collectors): agregar header net_usage.h con declaración de getNetUsage - Closes#157

### DIFF
--- a/src/collectors/network/net_usage.h
+++ b/src/collectors/network/net_usage.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+
+typedef struct {
+    uint64_t rx_bytes;
+    uint64_t tx_bytes;
+} NetInfo;
+
+NetInfo getNetUsage();


### PR DESCRIPTION
## ¿Qué hace este PR?
Se agrega el archivo de cabecera `src/collectors/network/net_usage.h` para el collector de red. El archivo define la estructura `NetInfo` con los campos `rx_bytes` y `tx_bytes` de tipo `uint64_t`, y declara la función `getNetUsage()` que retorna dicha estructura. No se modifica ningún archivo que no esté dentro de la descripción del Issue.

## Issue relacionado
Closes #157

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde