### PR TITLE
feat(collectors): agregar header ram_usage.h con declaración de getRamUsage

### DIFF
--- a/src/collectors/memory/ram_usage.h
+++ b/src/collectors/memory/ram_usage.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pulso::collectors::memory {
+
+/**
+ * @brief Contiene la informacion de uso de memoria RAM del sistema.
+ */
+struct RamInfo {
+    /** @brief Memoria total disponible en el sistema, expresada en bytes. */
+    uint64_t total;
+
+    /** @brief Memoria actualmente en uso, expresada en bytes. */
+    uint64_t used;
+
+    /** @brief Memoria disponible para ser utilizada, expresada en bytes. */
+    uint64_t available;
+};
+
+/**
+ * @brief Obtiene las metricas actuales de uso de memoria RAM del sistema.
+ * @return RamInfo con los valores de memoria total, usada y disponible.
+ */
+RamInfo getRamUsage();
+
+} // namespace pulso::collectors::memory


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el archivo src/collectors/memory/ram_usage.h con #pragma once, la estructura RamInfo con campos total, used y available de tipo uint64_t, y la declaración de getRamUsage() dentro del namespace pulso::collectors::memory.

## Issue relacionado
Closes #155 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Verificacion de sintaxis 
<img width="712" height="131" alt="image" src="https://github.com/user-attachments/assets/e1cbc148-a91f-4be4-b6e0-704d16f1c271" />
