### PR TITLE
fix(docs): corregir inconsistencia de idioma y añadir sección de deci…

### DIFF
--- a/docs/estandares-codigo.md
+++ b/docs/estandares-codigo.md
@@ -177,10 +177,17 @@ int main() {
   return 0;
 }
 ```
+
+## 📢 Decisión final del equipo sobre el idioma del código
+
+Tras revisar la inconsistencia entre la conclusión previa y los ejemplos técnicos del estándar de Google, el equipo ha determinado:
+- **Estandarización:** Todo el código fuente (variables, funciones, clases y archivos) debe escribirse obligatoriamente en **Inglés**.
+- **Justificación:** Se busca asegurar la compatibilidad con herramientas de análisis estático, facilitar la integración de librerías externas y prepararnos para entornos profesionales globales.
+
 ## 🔥 Conclusión rápida
 - snake_case → variables
 - PascalCase → funciones y tipos
 - 2 espacios → indentación
 - .cc / .h → archivos
 - Consistencia > preferencias personales
-- Código → Español
+- Código → Inglés


### PR DESCRIPTION
## ¿Qué hace este PR?
Se ha corregido una inconsistencia crítica en el documento de estándares de C++. Aunque los ejemplos técnicos seguían la convención de Google (en inglés), la conclusión indicaba erróneamente el uso del español. Este PR establece formalmente el **inglés** como el estándar para identificadores y archivos, añadiendo además una sección de "Decisión Final del Equipo" para dar contexto profesional y académico a la elección.

## Issue relacionado
Closes #72

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1103" height="669" alt="image" src="https://github.com/user-attachments/assets/6ed98d55-d246-4955-972e-8bef82e82cf5" />
<img width="667" height="249" alt="image" src="https://github.com/user-attachments/assets/8669e9da-d5c7-4dd8-a007-34ffb33e04e8" />