### PR TITLE
feat(storage): definir esquema SQLite y migración inicial #88

### DIFF
--- a/src/storage/schema.cpp
+++ b/src/storage/schema.cpp
@@ -1,0 +1,32 @@
+#include "schema.hpp"
+
+namespace pulso::storage {
+
+void inicializarEsquema(SQLite::Database& db) {
+
+    // Crear tabla snapshots si no existe
+    db.exec(
+        "CREATE TABLE IF NOT EXISTS snapshots ("
+        "    id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "    timestamp INTEGER NOT NULL,"
+        "    cpu_usage REAL,"
+        "    cpu_cores INTEGER,"
+        "    memory_total INTEGER,"
+        "    memory_used INTEGER,"
+        "    memory_available INTEGER,"
+        "    disk_total INTEGER,"
+        "    disk_used INTEGER,"
+        "    disk_free INTEGER,"
+        "    network_rx_bytes INTEGER,"
+        "    network_tx_bytes INTEGER"
+        ");"
+    );
+
+    // Crear índice sobre timestamp si no existe
+    db.exec(
+        "CREATE INDEX IF NOT EXISTS idx_snapshots_timestamp "
+        "ON snapshots(timestamp);"
+    );
+}
+
+} 

--- a/src/storage/schema.hpp
+++ b/src/storage/schema.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <SQLiteCpp/SQLiteCpp.h>
+
+namespace pulso::storage {
+
+/**
+ * @brief Crea las tablas e índices necesarios en la base de datos.
+ *
+ * Inicializa el esquema de la base de datos SQLite creando la tabla
+ * `snapshots` y el índice `idx_snapshots_timestamp` si no existen.
+ * La función es idempotente: puede llamarse varias veces sin errores.
+ *
+ * @param db Referencia a la base de datos SQLite abierta.
+ */
+void inicializarEsquema(SQLite::Database& db);
+
+} 


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea schema.hpp y schema.cpp en src/storage/ con la función
inicializarEsquema() que crea la tabla snapshots y el índice
idx_snapshots_timestamp usando CREATE IF NOT EXISTS.
La función es idempotente y está documentada con Doxygen.

## Issue relacionado
Closes #88

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="461" height="347" alt="image" src="https://github.com/user-attachments/assets/4e344840-ba29-40d7-816f-a08ea671976a" />
