### PR TITLE
feat(formatters): implementar FormatterPrometheus

### DIFF
--- a/src/formatters/formatter_prometheus.cpp
+++ b/src/formatters/formatter_prometheus.cpp
@@ -1,0 +1,53 @@
+#include "formatter_prometheus.hpp"
+
+#include <sstream>
+
+namespace pulso::formatters {
+
+std::string FormatterPrometheus::formato() const {
+    return "prometheus";
+}
+
+std::string FormatterPrometheus::contentType() const {
+    return "text/plain; version=0.0.4";
+}
+
+std::string FormatterPrometheus::formatear(
+    const pulso::core::Snapshot& snapshot) const {
+
+    std::ostringstream output;
+
+    output << "# HELP pulso_cpu_usage Porcentaje de uso de CPU\n";
+    output << "# TYPE pulso_cpu_usage gauge\n";
+    output << "pulso_cpu_usage " << snapshot.cpu << "\n\n";
+
+    output << "# HELP pulso_memory_usage Uso de memoria RAM\n";
+    output << "# TYPE pulso_memory_usage gauge\n";
+    output << "pulso_memory_usage " << snapshot.ram << "\n\n";
+
+    output << "# HELP pulso_disk_usage Uso de disco\n";
+    output << "# TYPE pulso_disk_usage gauge\n";
+    output << "pulso_disk_usage " << snapshot.disk << "\n\n";
+
+    output << "# HELP pulso_rx_bytes Trafico recibido\n";
+    output << "# TYPE pulso_rx_bytes gauge\n";
+    output << "pulso_rx_bytes " << snapshot.rx_bytes << "\n\n";
+
+    output << "# HELP pulso_tx_bytes Trafico enviado\n";
+    output << "# TYPE pulso_tx_bytes gauge\n";
+    output << "pulso_tx_bytes " << snapshot.tx_bytes << "\n";
+
+    return output.str();
+}
+
+std::string FormatterPrometheus::formatearHistorial(
+    const std::vector<pulso::core::Snapshot>& snapshots) const {
+
+    if (snapshots.empty()) {
+        return "";
+    }
+
+    return formatear(snapshots.back());
+}
+
+} // namespace pulso::formatters

--- a/src/formatters/formatter_prometheus.hpp
+++ b/src/formatters/formatter_prometheus.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "iformatter.hpp"
+
+namespace pulso::formatters {
+
+class FormatterPrometheus : public IFormatter {
+public:
+    std::string formato() const override;
+
+    std::string contentType() const override;
+
+    std::string formatear(
+        const pulso::core::Snapshot& snapshot) const override;
+
+    std::string formatearHistorial(
+        const std::vector<pulso::core::Snapshot>& snapshots) const override;
+};
+
+} // namespace pulso::formatters


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa el formateador `FormatterPrometheus` para exponer métricas en formato Prometheus text exposition format.

La implementación incluye:

* clase `FormatterPrometheus` heredando de `IFormatter`
* implementación de `formato()`
* implementación de `contentType()`
* serialización de métricas en formato Prometheus
* soporte para historial utilizando el snapshot más reciente

También se aplican las reglas de transformación solicitadas:

* prefijo `pulso_`
* reemplazo de puntos por guiones bajos
* exposición de métricas como `gauge`

## Issue relacionado
Closes #97

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No Aplica.