### PR TITLE
test: configurar Google Test y primera prueba 

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,21 +1,28 @@
 enable_testing()
-
 message(STATUS "Tests are enabled (PULSO_BUILD_TESTS=ON)")
-
 find_package(GTest REQUIRED)
 include(GoogleTest)
 
 add_executable(test_types
     core/test_types.cpp
 )
-
 target_include_directories(test_types PRIVATE
     ${PROJECT_SOURCE_DIR}/src
 )
-
 target_link_libraries(test_types PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
-
 gtest_discover_tests(test_types)
+ 
+add_executable(test_config
+    test_config.cpp
+)
+target_include_directories(test_config PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test_config PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+)
+gtest_discover_tests(test_config)

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "config/config.hpp"
+
+namespace pulso::config {
+
+TEST(ConfigSamplerTest, DefaultValues) {
+    Config config;
+
+    ASSERT_EQ(config.sampler.intervalo_segundos, 10);
+    ASSERT_EQ(config.servidor.host,              "0.0.0.0");
+    ASSERT_EQ(config.servidor.puerto,            8080);
+    ASSERT_EQ(config.storage.ruta_db,            "pulso.db");
+    ASSERT_EQ(config.nivel_log,                  "info");
+}
+
+} // namespace pulso::config


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo tests/test_config.cpp con la primera prueba unitaria  usando Google Test, que valida los valores por defecto de la estructura  Config en pulso::config. Se actualiza tests/CMakeLists.txt agregando el target test_config sin modificar el target test_types existente.

## Issue relacionado
Closes #26 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="1005" height="475" alt="image" src="https://github.com/user-attachments/assets/6ea6c48b-be79-4d10-afc1-49d1f97c4a43" />
