### PR TITLE
feat: implementar lectura de RAM desde /proc/meminfo

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,9 @@ double ObtenerUsoCPU();
 // utils/disk_usage.cpp
 double getDiskUsage();
 
+// utils/ram_usage.cpp
+double getRAMUsage();
+
 // collectors/network/network_io.cpp
 struct NetworkIO { long rx; long tx; };
 NetworkIO getNetworkIO();
@@ -40,6 +43,7 @@ void start(int intervalo_ms) {
         // 1. Actualizar el mapa con las lecturas de cada collector
         std::map<std::string, double> metricas;
         metricas["cpu"]    = ObtenerUsoCPU();
+        metricas["ram"]    = getRAMUsage();
         metricas["disk"]   = getDiskUsage();
 
         NetworkIO net      = getNetworkIO();

--- a/src/utils/ram_usage.cpp
+++ b/src/utils/ram_usage.cpp
@@ -1,0 +1,41 @@
+#include "ram_usage.hpp"
+
+#include <fstream>
+#include <string>
+#include <stdexcept>
+
+double getRAMUsage() {
+    std::ifstream file("/proc/meminfo");
+
+    if (!file.is_open()) {
+        throw std::runtime_error("No se pudo abrir /proc/meminfo");
+    }
+
+    std::string line;
+
+    unsigned long long memTotal = 0;
+    unsigned long long memAvailable = 0;
+
+    while (std::getline(file, line)) {
+
+        if (line.find("MemTotal:") == 0) {
+
+            std::string value = line.substr(10);
+
+            memTotal = std::stoull(value);
+        }
+
+        if (line.find("MemAvailable:") == 0) {
+
+            std::string value = line.substr(14);
+
+            memAvailable = std::stoull(value);
+        }
+    }
+
+    if (memTotal == 0 || memAvailable == 0) {
+        throw std::runtime_error("No se pudieron leer datos de memoria");
+    }
+
+    return ((memTotal - memAvailable) * 100.0) / memTotal;
+}

--- a/src/utils/ram_usage.hpp
+++ b/src/utils/ram_usage.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+double getRAMUsage();


### PR DESCRIPTION
## ¿Qué hace este PR?

Se implementa la lectura de uso de memoria RAM desde `/proc/meminfo`.

La implementación:

* Lee `MemTotal` y `MemAvailable`
* Calcula el porcentaje de RAM usada
* Maneja errores si el archivo no existe o no puede leerse
* Integra la métrica RAM al loop principal de monitoreo

## Issue relacionado

Closes #25 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

<img width="1188" height="306" alt="image" src="https://github.com/user-attachments/assets/d1279fdd-710e-430d-a9ec-0ac2510089f8" />

Debido a que `/proc/meminfo` es una interfaz exclusiva de Linux, la ejecución completa no puede validarse localmente en Windows. La validación final será realizada por el entorno CI/Linux del proyecto.
