### PR TITLE
feat: implement basic command-line argument parser - Closes #29

### DIFF
--- a/src/cli/arg_parser.cpp
+++ b/src/cli/arg_parser.cpp
@@ -1,0 +1,131 @@
+#include "arg_parser.h"
+
+#include <iostream>
+#include <sstream>
+#include <string>
+
+/**
+ * @brief Procesa la lista de métricas y actualiza la configuración.
+ *
+ * Ejemplo:
+ * --metrics cpu,ram
+ */
+static void parse_metrics(const std::string& metrics, MonitorConfig& config)
+{
+    /**
+     * Primero deshabilitamos todas las métricas.
+     * Luego habilitamos únicamente las indicadas.
+     */
+    config.cpu = false;
+    config.ram = false;
+    config.disk = false;
+
+    std::stringstream ss(metrics);
+
+    std::string item;
+
+    while (std::getline(ss, item, ','))
+    {
+        if (item == "cpu")
+        {
+            config.cpu = true;
+        }
+        else if (item == "ram")
+        {
+            config.ram = true;
+        }
+        else if (item == "disk")
+        {
+            config.disk = true;
+        }
+    }
+}
+
+void print_help()
+{
+    std::cout << "Uso:\n";
+    std::cout << "  monitor [opciones]\n\n";
+
+    std::cout << "Opciones:\n";
+    std::cout << "  --interval <ms>      Intervalo de lectura\n";
+    std::cout << "  --metrics <lista>    cpu,ram,disk\n";
+    std::cout << "  -h, --help           Mostrar ayuda\n";
+}
+
+bool parse_arguments(int argc, char* argv[], MonitorConfig& config)
+{
+    /**
+     * Recorremos argv manualmente.
+     */
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+
+        /**
+         * Mostrar ayuda.
+         */
+        if (arg == "-h" || arg == "--help")
+        {
+            print_help();
+            return false;
+        }
+
+        /**
+         * Procesar intervalo.
+         */
+        else if (arg == "--interval")
+        {
+            /**
+             * Verificar que exista un valor después.
+             */
+            if (i + 1 >= argc)
+            {
+                std::cerr << "Error: falta valor para --interval\n";
+                return false;
+            }
+
+            int interval = std::stoi(argv[++i]);
+
+            /**
+             * Validación requerida por la issue.
+             */
+            if (interval <= 100)
+            {
+                std::cerr << "Error: interval debe ser mayor a 100ms\n";
+                return false;
+            }
+
+            config.interval_ms = interval;
+        }
+
+        /**
+         * Procesar métricas.
+         */
+        else if (arg == "--metrics")
+        {
+            /**
+             * Validar existencia del valor.
+             */
+            if (i + 1 >= argc)
+            {
+                std::cerr << "Error: falta valor para --metrics\n";
+                return false;
+            }
+
+            parse_metrics(argv[++i], config);
+        }
+
+        /**
+         * Argumento desconocido.
+         */
+        else
+        {
+            std::cerr << "Error: argumento desconocido -> "
+                      << arg << "\n";
+
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/src/cli/arg_parser.h
+++ b/src/cli/arg_parser.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "../config.hpp"
+
+/**
+ * @brief Procesa argumentos de línea de comandos.
+ *
+ * Permite sobrescribir valores dentro de MonitorConfig.
+ *
+ * Argumentos soportados:
+ * - --interval <ms>
+ * - --metrics <lista>
+ * - -h | --help
+ *
+ * @param argc Cantidad de argumentos.
+ * @param argv Vector de argumentos.
+ * @param config Configuración a modificar.
+ *
+ * @return true si la ejecución puede continuar.
+ * @return false si ocurrió un error o se mostró ayuda.
+ */
+bool parse_arguments(int argc, char* argv[], MonitorConfig& config);
+
+/**
+ * @brief Muestra la ayuda del programa.
+ */
+void print_help();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,10 @@
 #include <map>
 #include <string>
 #include <thread>
+#include <iostream>
+
+#include "config/config.hpp"
+#include "cli/arg_parser.h"
 
 // --- Declaraciones de funciones existentes en otros archivos ---
 
@@ -54,8 +58,35 @@ void start(int intervalo_ms) {
     }
 }
 
-int main() {
+
+
+/**
+ * @brief Punto de entrada principal.
+ */
+int main(int argc, char* argv[])
+{
+    /**
+     * Configuración con valores por defecto.
+     */
+    MonitorConfig config;
+
+    /**
+     * Procesar argumentos CLI.
+     */
+    if (!parse_arguments(argc, argv, config))
+    {
+        return 1;
+    }
+
+    /**
+     * Configurar manejo de señales.
+     */
     setupSignalHandler();
-    start(1000);  // lectura cada 1000 ms
+
+    /**
+     * Iniciar monitoreo.
+     */
+    start(config.interval_ms);
+
     return 0;
 }


### PR DESCRIPTION
## ¿Qué hace este PR?

Esta PR implementa un parser básico de argumentos CLI para permitir configurar parámetros del monitor directamente desde línea de comandos.

### Cambios realizados
- Se agregó soporte para los argumentos:
    * --interval
   * --metrics
- Se implementó el parseo manual de argv desde main()
- Se añadió la sobrescritura de valores en MonitorConfig
- Se agregó soporte para mostrar ayuda usando -h
- Se validó que el intervalo sea mayor a 100ms

## Issue relacionado
Closes #29 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde