### PR TITLE
test: validar formateador de consola con GTest

### DIFF
--- a/tests/test_console_formatter.cpp
+++ b/tests/test_console_formatter.cpp
@@ -1,0 +1,32 @@
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <map>
+#include <string>
+#include <iostream>
+
+// Declaración de la función
+void printMetrics(const std::map<std::string, double>& data);
+
+TEST(ConsoleFormatterTest, OutputContainsMetrics) {
+    std::map<std::string, double> data = {
+        {"CPU", 25.5},
+        {"RAM", 40.0}
+    };
+
+    std::ostringstream output;
+
+    // Redirigir std::cout
+    auto* oldCout = std::cout.rdbuf(output.rdbuf());
+
+    // Llamar formateador con datos mock
+    printMetrics(data);
+
+    // Limpiar/restaurar stream
+    std::cout.rdbuf(oldCout);
+
+    std::string result = output.str();
+
+    EXPECT_NE(result.find("CPU:"), std::string::npos);
+    EXPECT_NE(result.find("RAM:"), std::string::npos);
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega una prueba unitaria para validar la salida del formateador de consola utilizando GoogleTest.

La prueba:

* Redirige `std::cout` hacia `std::ostringstream`
* Usa datos mock para simular métricas
* Verifica que la salida contenga los nombres de métricas esperados (`CPU:` y `RAM:`)
* Restaura el stream original después de la ejecución

## Issue relacionado
Closes #41

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Se añadió el archivo:

* `tests/test_console_formatter.cpp`

La prueba valida correctamente la salida generada por `printMetrics`.
