### PR TITLE
chore: configure src include directories

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,7 @@
 add_executable(pulso main.cpp)
+
 target_compile_features(pulso PRIVATE cxx_std_17)
+
+target_include_directories(pulso PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
## ¿Qué hace este PR?
Configura correctamente los directorios de inclusión del target principal `pulso` en `src/CMakeLists.txt`.

Con este cambio, los headers internos del proyecto pueden incluirse de forma limpia usando rutas como:

```cpp
#include "config/config.hpp"
#include "cli/arg_parser.h"
```
## Issue relacionado
Closes #195 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

La compilación se detiene posteriormente por un error existente en src/main.cpp, no relacionado con este cambio:

error: 'std::this_thread' has not been declared

No se modificó main.cpp porque está fuera del alcance del issue.
<img width="1058" height="102" alt="00pintura" src="https://github.com/user-attachments/assets/f5c75c32-b504-4f81-a8cf-d523c3e57844" />
