### PR TITLE
feat: add MonitorConfig structure

### DIFF
--- a/src/config/config.hpp
+++ b/src/config/config.hpp
@@ -19,7 +19,24 @@ public:
 // ---------------------------------------------------------------------------
 // Estructuras de configuración
 // ---------------------------------------------------------------------------
+/// Configuración del monitor del sistema.
+struct MonitorConfig
+{
+    /// Intervalo de actualización de métricas en milisegundos.
+    int interval_ms = 1000;
 
+    /// Habilita la lectura de métricas de CPU.
+    bool cpu = true;
+
+    /// Habilita la lectura de métricas de RAM.
+    bool ram = true;
+
+    /// Habilita la lectura de métricas de disco.
+    bool disk = true;
+
+    /// Constructor con valores por defecto.
+    MonitorConfig() = default;
+};
 struct ConfigServidor {
     std::string host  = "0.0.0.0";
     int         puerto = 8080;


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la estructura `MonitorConfig` en `src/config/config.hpp`.

Esta estructura permite centralizar la configuración del monitor del sistema, incluyendo el intervalo de actualización de métricas y las métricas habilitadas: CPU, RAM y disco.

## Issue relacionado
Closes #196 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas