### PR TITLE
chore: añadir .clang-format con estilo LLVM e IndentWidth 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,3 @@
-BasedOnStyle: Google
-IndentWidth: 4
-ColumnLimit: 100
-AccessModifierOffset: -2
-AllowShortFunctionsOnASingleLine: Inline
+---
+BasedOnStyle: LLVM
+IndentWidth: 2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,12 @@
 #include <atomic>
 #include <chrono>
+#include <iostream>
 #include <map>
 #include <string>
 #include <thread>
-#include <iostream>
 
-#include "config/config.hpp"
 #include "cli/arg_parser.h"
+#include "config/config.hpp"
 
 // --- Declaraciones de funciones existentes en otros archivos ---
 
@@ -20,11 +20,14 @@ double getDiskUsage();
 double getRAMUsage();
 
 // collectors/network/network_io.cpp
-struct NetworkIO { long rx; long tx; };
+struct NetworkIO {
+  long rx;
+  long tx;
+};
 NetworkIO getNetworkIO();
 
 // utils/console_formatter.cpp
-void printMetrics(const std::map<std::string, double>& data);
+void printMetrics(const std::map<std::string, double> &data);
 
 // utils/signal_handler.cpp
 void setupSignalHandler();
@@ -43,54 +46,50 @@ extern std::atomic<bool> isRunning;
  * @param intervalo_ms Tiempo de espera entre lecturas, en milisegundos.
  */
 void start(int intervalo_ms) {
-    while (isRunning) {
-        // 1. Actualizar el mapa con las lecturas de cada collector
-        std::map<std::string, double> metricas;
-        metricas["cpu"]    = ObtenerUsoCPU();
-        metricas["ram"]    = getRAMUsage();
-        metricas["disk"]   = getDiskUsage();
+  while (isRunning) {
+    // 1. Actualizar el mapa con las lecturas de cada collector
+    std::map<std::string, double> metricas;
+    metricas["cpu"] = ObtenerUsoCPU();
+    metricas["ram"] = getRAMUsage();
+    metricas["disk"] = getDiskUsage();
 
-        NetworkIO net      = getNetworkIO();
-        metricas["net.rx"] = static_cast<double>(net.rx);
-        metricas["net.tx"] = static_cast<double>(net.tx);
+    NetworkIO net = getNetworkIO();
+    metricas["net.rx"] = static_cast<double>(net.rx);
+    metricas["net.tx"] = static_cast<double>(net.tx);
 
-        // 2. Llamar al formateador
-        printMetrics(metricas);
+    // 2. Llamar al formateador
+    printMetrics(metricas);
 
-        // 3. Esperar X ms antes del siguiente ciclo
-        std::this_thread::sleep_for(std::chrono::milliseconds(intervalo_ms));
-    }
+    // 3. Esperar X ms antes del siguiente ciclo
+    std::this_thread::sleep_for(std::chrono::milliseconds(intervalo_ms));
+  }
 }
-
-
 
 /**
  * @brief Punto de entrada principal.
  */
-int main(int argc, char* argv[])
-{
-    /**
-     * Configuración con valores por defecto.
-     */
-    MonitorConfig config;
+int main(int argc, char *argv[]) {
+  /**
+   * Configuración con valores por defecto.
+   */
+  MonitorConfig config;
 
-    /**
-     * Procesar argumentos CLI.
-     */
-    if (!parse_arguments(argc, argv, config))
-    {
-        return 1;
-    }
+  /**
+   * Procesar argumentos CLI.
+   */
+  if (!parse_arguments(argc, argv, config)) {
+    return 1;
+  }
 
-    /**
-     * Configurar manejo de señales.
-     */
-    setupSignalHandler();
+  /**
+   * Configurar manejo de señales.
+   */
+  setupSignalHandler();
 
-    /**
-     * Iniciar monitoreo.
-     */
-    start(config.interval_ms);
+  /**
+   * Iniciar monitoreo.
+   */
+  start(config.interval_ms);
 
-    return 0;
+  return 0;
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Unifica el formato de código fuente de los archivos C++ ubicados en el directorio `src/`. Para esto, se añade el archivo de configuración `.clang-format` en la raíz del proyecto basado en el estilo **LLVM** y con un ancho de sangría obligatorio de **2 espacios** (`IndentWidth: 2`), aplicando el formateo masivo de forma automatizada.

## Issue relacionado
Closes #28

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [X] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [X] Mi código sigue los estándares del proyecto
- [X] Actualicé la documentación correspondiente
- [X] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="749" height="704" alt="image" src="https://github.com/user-attachments/assets/6221b5be-3462-46f3-a126-2fad302913d9" />
<img width="643" height="435" alt="image" src="https://github.com/user-attachments/assets/67ff03c3-6e91-4c73-a8db-459dad55b105" />
