### PR TITLE
feat: implementar FormatterJSON

### DIFF
--- a/src/formatters/formatter_json.cpp
+++ b/src/formatters/formatter_json.cpp
@@ -1,0 +1,69 @@
+#include "formatter_json.hpp"
+
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+namespace pulso::formatters {
+
+std::string FormatterJSON::formato() const {
+    return "json";
+}
+
+std::string FormatterJSON::contentType() const {
+    return "application/json";
+}
+
+std::string FormatterJSON::formatear(
+    const pulso::core::Snapshot& snapshot
+) const {
+
+    json resultado;
+
+    resultado["timestamp"] = snapshot.timestamp;
+    resultado["metricas"] = json::array();
+
+    for (const auto& metrica : snapshot.metrics) {
+        resultado["metricas"].push_back({
+            {"nombre", metrica.name},
+            {"valor", metrica.value},
+            {"unidad", metrica.unit},
+            {"timestamp", metrica.timestamp}
+        });
+    }
+
+    return resultado.dump();
+}
+
+std::string FormatterJSON::formatearHistorial(
+    const std::vector<pulso::core::Snapshot>& snapshots
+) const {
+
+    json resultado;
+
+    resultado["total"] = snapshots.size();
+    resultado["snapshots"] = json::array();
+
+    for (const auto& snapshot : snapshots) {
+
+        json item;
+
+        item["timestamp"] = snapshot.timestamp;
+        item["metricas"] = json::array();
+
+        for (const auto& metrica : snapshot.metrics) {
+            item["metricas"].push_back({
+                {"nombre", metrica.name},
+                {"valor", metrica.value},
+                {"unidad", metrica.unit},
+                {"timestamp", metrica.timestamp}
+            });
+        }
+
+        resultado["snapshots"].push_back(item);
+    }
+
+    return resultado.dump();
+}
+
+}

--- a/src/formatters/formatter_json.hpp
+++ b/src/formatters/formatter_json.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "iformatter.hpp"
+#include "core/types.hpp"
+
+namespace pulso::formatters {
+
+/**
+ * @brief Formateador JSON para snapshots de métricas.
+ */
+class FormatterJSON : public IFormatter {
+public:
+    /**
+     * @brief Retorna el identificador del formato.
+     */
+    std::string formato() const override;
+
+    /**
+     * @brief Retorna el content type HTTP.
+     */
+    std::string contentType() const override;
+
+    /**
+     * @brief Serializa un snapshot individual.
+     */
+    std::string formatear(
+        const pulso::core::Snapshot& snapshot
+    ) const override;
+
+    /**
+     * @brief Serializa un historial de snapshots.
+     */
+    std::string formatearHistorial(
+        const std::vector<pulso::core::Snapshot>& snapshots
+    ) const override;
+};
+
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la clase FormatterJSON para serializar snapshots y métricas en formato JSON.

Incluye:
- Serialización de snapshots individuales
- Serialización de historial de snapshots
- Content-Type application/json
- JSON compacto usando nlohmann/json


## Issue relacionado
Closes #96 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se implementó correctamente FormatterJSON.