### PR TITLE
chore: añadir flags de compilación seguros

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,3 +5,4 @@ target_compile_features(pulso PRIVATE cxx_std_17)
 target_include_directories(pulso PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+target_compile_options(pulso PRIVATE -Wall -Wextra -Wpedantic -O2)


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega los flags de compilación -Wall -Wextra -Wpedantic -O2 al target pulso mediante target_compile_options en src/CMakeLists.txt.
Nota: no se modificó ningún Makefile ya que el proyecto utiliza 
exclusivamente CMake para la generación del sistema de construcción.

## Issue relacionado
Closes #39 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="739" height="308" alt="image" src="https://github.com/user-attachments/assets/543acf56-6fb7-4c91-84d4-bbe300cb7050" />
