### PR TITLE
chore: añadir flags de compilación seguros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # ==============================================================================
 
 CXX     ?= g++
-CXXFLAGS = -std=c++17 -Wall
+CXXFLAGS = -std=c++17 -Wall -Wextra -Wpedantic -O2
 
 SRC_DIR  = src
 TEST_DIR = tests

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,3 +5,4 @@ target_compile_features(pulso PRIVATE cxx_std_17)
 target_include_directories(pulso PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+target_compile_options(pulso PRIVATE -Wall -Wextra -Wpedantic -O2)


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega los flags de compilación -Wall -Wextra -Wpedantic -O2 en src/CMakeLists.txt mediante target_compile_options y en el Makefile actualizando CXXFLAGS, asegurando consistencia entre ambos sistemas de compilación. No se incluye -Werror.

## Issue relacionado
Closes #39 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="739" height="308" alt="image" src="https://github.com/user-attachments/assets/c48c4bf3-c42b-45d4-a257-333b1f047bfb" />
<img width="869" height="674" alt="image" src="https://github.com/user-attachments/assets/2800701b-fe0c-4a0c-9e60-9ee3292d4144" />
