### PR TITLE
fix: agregar namespace pulso::storage a schema.hpp y schema.cpp

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -10,7 +10,7 @@ Storage::Storage(const std::string& dbPath)
     db_.exec("PRAGMA journal_mode=WAL;");
  
     // Inicializar esquema (idempotente)
-    inicializarEsquema(db_);
+    pulso::storage::inicializarEsquema(db_);
 }
  
 void Storage::save(const pulso::core::Snapshot& snapshot) {


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza la llamada a inicializarEsquema() en src/storage/storage.cpp para usar el namespace completo ```pulso::storage::inicializarEsquema()```, manteniendo consistencia con la arquitectura del proyecto. 
Los archivos schema.hpp y schema.cpp ya contaban con el namespace correcto por lo que no requirieron modificaciones.

## Issue relacionado
Closes #222


## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="816" height="768" alt="image" src="https://github.com/user-attachments/assets/8a177cb6-fd7f-40b4-bd76-347675f52729" />
