### PR TITLE
fix: corregir el mensaje de error en getRamUsage() para que incluya información útil

### DIFF
--- a/src/collectors/memory/ram_usage.cpp
+++ b/src/collectors/memory/ram_usage.cpp
@@ -38,6 +38,8 @@ RamUsage getRamUsage() {
 
     if (memTotal == 0 || memAvailable == 0) {
         throw runtime_error("No se encontraron las claves MemTotal o MemAvailable en /proc/meminfo");
+    }
+
     memTotal *= 1024;
     memAvailable *= 1024;
 

--- a/src/collectors/memory/ram_usage.cpp
+++ b/src/collectors/memory/ram_usage.cpp
@@ -13,7 +13,7 @@ RamUsage getRamUsage() {
     ifstream file("/proc/meminfo");
 
     if (!file.is_open()) {
-        throw runtime_error("No se pudo abrir /proc/meminfo");
+        throw runtime_error("No se pudo abrir el archivo /proc/meminfo: verifique permisos y disponibilidad del sistema");
     }
 
     string line;
@@ -37,9 +37,7 @@ RamUsage getRamUsage() {
     }
 
     if (memTotal == 0 || memAvailable == 0) {
-        throw runtime_error("No se pudieron leer los datos de memoria");
-    }
-
+        throw runtime_error("No se encontraron las claves MemTotal o MemAvailable en /proc/meminfo");
     memTotal *= 1024;
     memAvailable *= 1024;
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Mejora los mensajes de error en getRamUsage() dentro de ```src/collectors/memory/ram_usage.cpp```. El primer mensaje ahora indica explícitamente que no se pudo abrir /proc/meminfo, y el segundo especifica qué claves (MemTotal o MemAvailable) no fueron encontradas. 
No se modificó la lógica de cuándo se lanzan las excepciones.

## Issue relacionado
Closes #231 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1109" height="429" alt="image" src="https://github.com/user-attachments/assets/1d7f0f88-2bfe-4cdc-bfbf-10123f16b515" />
<img width="952" height="684" alt="image" src="https://github.com/user-attachments/assets/0a13b189-5bd2-4e1d-9977-6b226d9d7e44" />
