### PR TITLE
feat: implementar sampler thread - Closes #102

### DIFF
--- a/src/sampler/sampler.cpp
+++ b/src/sampler/sampler.cpp
@@ -1,0 +1,103 @@
+#include "sampler.hpp"
+
+#include <chrono>
+#include <ctime>
+#include <iostream>
+
+namespace pulso::sampler {
+
+Sampler::Sampler(
+    std::vector<std::shared_ptr<pulso::collectors::ICollector>> collectors,
+    pulso::storage::Storage& storage,
+    int intervaloSegundos)
+    : collectors_(std::move(collectors)),
+      storage_(storage),
+      intervaloSegundos_(intervaloSegundos) {}
+
+Sampler::~Sampler() {
+    detener();
+}
+
+void Sampler::iniciar() {
+    if (corriendo_) {
+        return;
+    }
+
+    corriendo_ = true;
+
+    thread_ = std::thread([this]() {
+        while (corriendo_) {
+
+            auto timestamp =
+                static_cast<std::int64_t>(std::time(nullptr));
+
+            pulso::core::Snapshot snapshot;
+            snapshot.timestamp = timestamp;
+
+            for (const auto& collector : collectors_) {
+
+                try {
+
+                    auto metricas =
+                        collector->recolectar();
+
+                    snapshot.metrics.insert(
+                        snapshot.metrics.end(),
+                        metricas.begin(),
+                        metricas.end());
+
+                } catch (const std::exception& e) {
+
+                    std::cerr
+                        << "Error en collector "
+                        << collector->nombre()
+                        << ": "
+                        << e.what()
+                        << std::endl;
+                }
+            }
+
+            try {
+
+                storage_.save(snapshot);
+
+            } catch (const std::exception& e) {
+
+                std::cerr
+                    << "Error al guardar snapshot: "
+                    << e.what()
+                    << std::endl;
+            }
+
+            std::unique_lock<std::mutex> lock(mutex_);
+
+            cv_.wait_for(
+                lock,
+                std::chrono::seconds(intervaloSegundos_),
+                [this]() {
+                    return !corriendo_;
+                });
+        }
+    });
+}
+
+void Sampler::detener() {
+
+    if (!corriendo_) {
+        return;
+    }
+
+    corriendo_ = false;
+
+    cv_.notify_all();
+
+    if (thread_.joinable()) {
+        thread_.join();
+    }
+}
+
+bool Sampler::corriendo() const {
+    return corriendo_;
+}
+
+} // namespace pulso::sampler

--- a/src/sampler/sampler.hpp
+++ b/src/sampler/sampler.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "../collectors/icollector.hpp"
+#include "../core/types.hpp"
+#include "../storage/storage.hpp"
+
+namespace pulso::sampler {
+
+class Sampler {
+public:
+    Sampler(
+        std::vector<std::shared_ptr<pulso::collectors::ICollector>> collectors,
+        pulso::storage::Storage& storage,
+        int intervaloSegundos);
+
+    ~Sampler();
+
+    /// Inicia el thread de muestreo. No bloquea.
+    void iniciar();
+
+    /// Solicita la detención y espera a que el thread termine.
+    void detener();
+
+    /// Devuelve true si el sampler está corriendo.
+    bool corriendo() const;
+
+private:
+    std::vector<std::shared_ptr<pulso::collectors::ICollector>> collectors_;
+    pulso::storage::Storage& storage_;
+    int intervaloSegundos_;
+
+    std::thread thread_;
+    std::atomic<bool> corriendo_{false};
+    std::condition_variable cv_;
+    std::mutex mutex_;
+};
+
+} // namespace pulso::sampler


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa la clase `Sampler` encargada de ejecutar periódicamente los collectors registrados, construir snapshots y persistirlos usando Storage.

## Issue relacionado

Closes #102

## Tipo de cambio

* [x] feat — nueva funcionalidad

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Mis cambios no rompen funcionalidad existente

## Cambios realizados

* Implementación de `Sampler`
* Creación de `sampler.hpp`
* Creación de `sampler.cpp`
* Manejo de thread de muestreo
* Uso de `condition_variable`
* Manejo de excepciones por collector
* Persistencia de snapshots
* Detención segura del thread

## Evidencia / capturas
<img width="1186" height="641" alt="Prueba" src="https://github.com/user-attachments/assets/5945b787-48f6-4882-bab3-538d03475edf" />
