### PR TITLE
fix: corregir cpu_usage.hpp para que CollectorCPU herede de ICollector - Closes #224

### DIFF
--- a/src/collectors/cpu/cpu_usage.cpp
+++ b/src/collectors/cpu/cpu_usage.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 #include <thread>
 #include <chrono>
+#include <ctime>
 
 /// @brief Lee y parsea los contadores de CPU desde /proc/stat.
 /// @param ruta Ruta al archivo de estadísticas.
@@ -107,3 +108,24 @@ double ObtenerUsoCPU() {
 
   return uso;
 }
+
+// Implementación de CollectorCPU 
+ 
+namespace pulso::collectors {
+ 
+std::string CollectorCPU::nombre() const {
+  return "cpu";
+}
+ 
+std::vector<pulso::core::Metrica> CollectorCPU::recolectar() {
+  pulso::core::Metrica metrica;
+  metrica.name      = "cpu.usage";
+  metrica.value     = ObtenerUsoCPU();
+  metrica.unit      = "porcentaje";
+  metrica.timestamp = static_cast<std::int64_t>(std::time(nullptr));
+ 
+  return { metrica };
+}
+ 
+}  // namespace pulso::collectors
+ 

--- a/src/collectors/cpu/cpu_usage.h
+++ b/src/collectors/cpu/cpu_usage.h
@@ -3,6 +3,8 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
+#include "../../collectors/icollector.hpp"
 
 /// @brief Estructura que representa los contadores de tiempo de CPU
 /// obtenidos desde la primera línea de /proc/stat.
@@ -39,5 +41,33 @@ uint64_t CalcularTicksOciosos(const ContadoresCPU& c);
 /// @return Porcentaje de uso de CPU.
 /// @note Si ocurre un error o los datos no son válidos, retorna 0.0.
 double ObtenerUsoCPU();
-
+namespace pulso::collectors {
+ 
+/**
+ * @brief Recolector de métricas de CPU.
+ *
+ * Implementa la interfaz ICollector para ser compatible con el sistema
+ * de colección del proyecto. Obtiene el porcentaje de uso de CPU
+ * leyendo /proc/stat mediante la lógica ya existente en ObtenerUsoCPU().
+ */
+class CollectorCPU : public ICollector {
+ public:
+  /**
+   * @brief Devuelve el nombre identificador de este collector.
+   * @return La cadena "cpu".
+   */
+  std::string nombre() const override;
+ 
+  /**
+   * @brief Ejecuta una medición de CPU y devuelve las métricas obtenidas.
+   *
+   * Invoca ObtenerUsoCPU() para leer /proc/stat y calcula el porcentaje
+   * de uso. Devuelve una métrica con nombre "cpu.usage" y unidad "porcentaje".
+   *
+   * @return Vector con la métrica de uso de CPU.
+   */
+  std::vector<pulso::core::Metrica> recolectar() override;
+};
+ 
+}  // namespace pulso::collectors
 #endif // CPU_USAGE_H


### PR DESCRIPTION
## ¿Qué hace este PR?
Se refactoriza el recolector `CollectorCPU` para que herede formalmente de la interfaz unificada `ICollector`. Esta modificación asegura que el componente cumpla con el diseño polimórfico del sistema y exponga de manera correcta los métodos virtuales requeridos para la recolección automática de métricas.

## Issue relacionado
Closes #224 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica