### PR TITLE
fix: agregar namespace pulso::collectors a cpu_usage.hpp y cpu_usage.cpp #221

### DIFF
--- a/src/platform/linux/collector_cpu.cpp
+++ b/src/platform/linux/collector_cpu.cpp
@@ -9,6 +9,8 @@
 #include <cctype>
 #include <string>
 
+namespace pulso::collectors {
+
 // Estructura interna para leer /proc/stat
 struct CPUStat {
     unsigned long user = 0;
@@ -21,7 +23,7 @@ struct CPUStat {
     unsigned long steal = 0;
 };
 
-// Leer primera línea de /proc/stat
+// Leer primera linea de /proc/stat
 CPUStat leerCPU() {
     std::ifstream file("/proc/stat");
 
@@ -51,12 +53,11 @@ double calcularUso(const CPUStat& a, const CPUStat& b) {
 
     unsigned long totalA = a.user + a.nice + a.system + a.idle +
                            a.iowait + a.irq + a.softirq + a.steal;
-
     unsigned long totalB = b.user + b.nice + b.system + b.idle +
                            b.iowait + b.irq + b.softirq + b.steal;
 
     unsigned long totalDelta = totalB - totalA;
-    unsigned long idleDelta = idleB - idleA;
+    unsigned long idleDelta  = idleB  - idleA;
 
     if (totalDelta == 0) return 0;
 
@@ -97,9 +98,9 @@ std::vector<pulso::core::Metrica> CollectorCPU::recolectar() {
     CPUStat b = leerCPU();
 
     double usage = calcularUso(a, b);
-    int cores = contarCores();
+    int cores    = contarCores();
 
-    if (usage < 0) usage = 0;
+    if (usage < 0)   usage = 0;
     if (usage > 100) usage = 100;
 
     return {
@@ -107,3 +108,5 @@ std::vector<pulso::core::Metrica> CollectorCPU::recolectar() {
         pulso::core::Metrica{"cpu.cores", cores, "cantidad"}
     };
 }
+
+} // namespace pulso::collectors

--- a/src/platform/linux/collector_cpu.hpp
+++ b/src/platform/linux/collector_cpu.hpp
@@ -4,8 +4,12 @@
 #include <vector>
 #include <string>
 
+namespace pulso::collectors {
+
 class CollectorCPU : public ICollector {
 public:
     std::string nombre() const override;
     std::vector<Metrica> recolectar() override;
 };
+
+} // namespace pulso::collectors


### PR DESCRIPTION

## ¿Qué hace este PR?
Agrega el namespace pulso::collectors a collector_cpu.hpp y
collector_cpu.cpp. No se modificó la lógica de la clase,
solo se envolvió en el namespace correcto para ser consistente
con la interfaz ICollector.

## Issue relacionado
Closes #221

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica