### PR TITLE
fix: corregir CMakeLists.txt en src para incluir los archivos fuente reales - Closes#213

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,40 @@
 add_executable(pulso main.cpp)
 
+target_sources(pulso PRIVATE
+    cli/arg_parser.cpp
+    collectors/cpu/cpu_usage.cpp
+    collectors/disk/disk_usage.cpp
+    collectors/memory/ram_usage.cpp
+    collectors/network/network_io.cpp
+    collectors/network/net_usage.cpp
+    config/config.cpp
+    core/SystemMonitor.cpp
+    formatters/formatter_json.cpp
+    formatters/formatter_prometheus.cpp
+    http/handler_history.cpp
+    platform/linux/collector_cpu.cpp
+    sampler/sampler.cpp
+    storage/schema.cpp
+    storage/storage.cpp
+    utils/console_formatter.cpp
+    utils/disk_usage.cpp
+    utils/logging/logger.cpp
+    utils/ram_usage.cpp
+    utils/signal_handler.cpp
+)
+
 target_compile_features(pulso PRIVATE cxx_std_17)
 
 target_include_directories(pulso PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_link_libraries(pulso PRIVATE
+    httplib
+    nlohmann_json
+    tomlplusplus
+    SQLiteCpp
+    sqlite3
+)
+
 target_compile_options(pulso PRIVATE -Wall -Wextra -Wpedantic -O2)


### PR DESCRIPTION
## ¿Qué hace este PR?
El archivo `src/CMakeLists.txt` solo referenciaba `main.cpp`, dejando fuera todos los demás archivos fuente del proyecto. Esto provocaba que `cpu_usage.cpp`, `ram_usage.cpp`, `schema.cpp` y el resto de los módulos no se compilaran al ejecutar `cmake --build build`.

Cambios realizados
- Se agregaron todos los archivos .cpp existentes en src/ y sus subdirectorios al add_executable(pulso ...).
- Se añadió target_link_libraries con las dependencias externas ya declaradas en cmake/Dependencies.cmake (httplib, nlohmann_json, tomlplusplus, SQLiteCpp), necesarias para que el linker resuelva correctamente los símbolos usados en los módulos incorporados.
- Se conservaron sin modificación target_compile_features, target_include_directories y target_compile_options.

Archivos modificados
- `src/CMakeLists.txt`

## Issue relacionado
Closes #213 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde
