### PR TITLE
fix: alinear campos de Metrica y Snapshot - Closes #218

### DIFF
--- a/src/core/types.hpp
+++ b/src/core/types.hpp
@@ -14,13 +14,13 @@ namespace pulso::core {
  */
 struct Metrica {
     /** @brief Nombre identificador de la metrica. Ej: "cpu.usage", "ram.used" */
-    std::string name;
+    std::string nombre;
 
     /** @brief Valor numerico de la medicion */
-    double value;
+    double valor;
 
     /** @brief Unidad en que se expresa el valor. Ej: "porcentaje", "bytes" */
-    std::string unit;
+    std::string unidad;
 
     /** @brief Momento en que se tomo la medición, expresado como Unix timestamp en segundos. */
     std::int64_t timestamp;
@@ -37,6 +37,6 @@ struct Snapshot {
     std::int64_t timestamp;
 
     /** @brief Coleccion de métricas individuales capturadas en este snapshot. */
-    std::vector<Metrica> metrics;
+    std::vector<Metrica> metricas;
 };
 } // namespace pulso::core


### PR DESCRIPTION
## ?Qu? hace este PR?
Alinea `src/core/types.hpp` con el contrato pedido en el issue #218.

Cambios:
- `Metrica`: `name` -> `nombre`, `value` -> `valor`, `unit` -> `unidad`
- `Snapshot`: `metrics` -> `metricas`

No se tocaron otros archivos.

## Issue relacionado
Closes #218

## Tipo de cambio
- [ ] feat ? nueva funcionalidad
- [x] fix ? correcci?n de error
- [ ] docs ? documentaci?n
- [ ] test ? pruebas
- [ ] chore ? configuraci?n
- [ ] refactor ? mejora sin cambio funcional
- [ ] security ? seguridad
- [ ] data ? an?lisis de datos

## Checklist
- [x] Mi c?digo sigue los est?ndares del proyecto
- [x] Actualic? la documentaci?n correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregu? tests si corresponde

## Evidencia / capturas
- `cmake -S . -B build-no-tests -DPULSO_BUILD_TESTS=OFF` -> configure OK
- `cmake --build build-no-tests --config Release` falla en `SQLiteCpp_cpplint` por CRLF en dependencia externa (no relacionado a este cambio)
