### PR TITLE
fix: corregir el archivo .gitignore para excluir artefactos de compilacion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,7 @@ id_rsa.pub
 *.tmp
 *.temp
 *.bak
+# Agregados por requerimiento de Issue #228
+.cmake/
+*.db
+*.sqlite


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza el archivo `.gitignore` en la raíz del proyecto para asegurar que los artefactos de compilación generados por CMake (directorios `build/`, `.cmake/` y archivos binarios `*.o`, `*.a`) así como los archivos de base de datos local de SQLite (`*.db`, `*.sqlite`) queden excluidos del control de versiones.

## Issue relacionado
Closes #228

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] El PR se abre directamente contra la rama `dev`
- [x] Mis cambios no rompen funcionalidad existente
- [x] `build/`, `*.db` y `*.sqlite` están correctamente configurados en el .gitignore

## Evidencia / capturas
Se simularon los artefactos de compilación creando manualmente el directorio `build/` (con `main.o` dentro) y los archivos `datos.db` y `prueba.sqlite`. 

Como se observa en la captura de la terminal, al ejecutar `git status` el sistema ignora correctamente estos archivos y carpetas, demostrando la efectividad de las nuevas reglas agregadas al `.gitignore`.

<img width="935" height="117" alt="imagen" src="https://github.com/user-attachments/assets/18a08f85-cfad-4f8c-aaa8-49a7d2ca1be5" />

