### PR TITLE
feat: añadir versión estática y comando --version

### DIFF
--- a/src/cli/arg_parser.cpp
+++ b/src/cli/arg_parser.cpp
@@ -3,6 +3,9 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <cstdlib>
+
+#define PULSO_VERSION "0.1.0"
 
 /**
  * @brief Procesa la lista de métricas y actualiza la configuración.
@@ -69,7 +72,14 @@ bool parse_arguments(int argc, char* argv[], MonitorConfig& config)
             print_help();
             return false;
         }
+        else if (arg == "--version")
+       {
+            std::cout << "pulso v"
+                      << PULSO_VERSION
+                      << " (C++17) - 2026\n";
 
+            std::exit(0);
+        }
         /**
          * Procesar intervalo.
          */


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega soporte para el comando `--version` mostrando la versión estática y el año académico.

Salida esperada:

```bash id="zz001"
pulso --version
```

```text id="zz002"
pulso v0.1.0 (C++17) - 2026
```

## Issue relacionado

Closes #42

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1027" height="391" alt="Prueb" src="https://github.com/user-attachments/assets/9d00c9e2-6a6c-405f-954f-a6868b65b94f" />