### PR TITLE
feat(http): implementar endpoint /health 

### DIFF
--- a/src/http/handler_health.cpp
+++ b/src/http/handler_health.cpp
@@ -1,0 +1,21 @@
+#include "handler_health.hpp"
+
+namespace pulso::http {
+
+void registrarHealth(httplib::Server& servidor) {
+    servidor.Get("/health", [](const httplib::Request&, httplib::Response& res) {
+
+        res.set_content(
+            R"({
+  "status": "ok",
+  "service": "pulso",
+  "version": "0.1.0"
+})",
+            "application/json"
+        );
+
+        res.status = 200;
+    });
+}
+
+} // namespace pulso::http

--- a/src/http/handler_health.hpp
+++ b/src/http/handler_health.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <httplib.h>
+
+namespace pulso::http {
+
+/// Registra el handler de /health en el servidor httplib.
+void registrarHealth(httplib::Server& servidor);
+
+} // namespace pulso::http


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR implementa el endpoint `/health` para el servicio **pulso**, permitiendo verificar que el servidor está activo y respondiendo correctamente.  
El endpoint expone una ruta HTTP GET que retorna un JSON con el estado del sistema.

## Issue relacionado
Closes #98

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1559" height="599" alt="Evidencia" src="https://github.com/user-attachments/assets/469705d1-892c-4b78-a4f3-429d3e91c715" />