### PR TITLE
fix: corregir getRamUsage() para retornar los tres campos requeridos por el contrato - Closes #215

### DIFF
--- a/src/collectors/memory/ram_usage.cpp
+++ b/src/collectors/memory/ram_usage.cpp
@@ -1,41 +1,59 @@
-#include "ram_usage.hpp"
-
+#include "ram_usage.h"
 #include <fstream>
+#include <sstream>
 #include <string>
 #include <stdexcept>
 
-double getRAMUsage() {
+namespace pulso::collectors::memory {
+
+RamInfo getRamUsage() {
     std::ifstream file("/proc/meminfo");
 
     if (!file.is_open()) {
-        throw std::runtime_error("No se pudo abrir /proc/meminfo");
+        throw std::runtime_error(
+            "No se pudo abrir el archivo /proc/meminfo: "
+            "verifique permisos y disponibilidad del sistema"
+        );
     }
 
     std::string line;
-
-    unsigned long long memTotal = 0;
-    unsigned long long memAvailable = 0;
+    long long memTotal     = 0;
+    long long memAvailable = 0;
 
     while (std::getline(file, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        long long value;
 
-        if (line.find("MemTotal:") == 0) {
+        iss >> key >> value;
 
-            std::string value = line.substr(10);
-
-            memTotal = std::stoull(value);
+        if (key == "MemTotal:") {
+            memTotal = value;
         }
 
-        if (line.find("MemAvailable:") == 0) {
-
-            std::string value = line.substr(14);
-
-            memAvailable = std::stoull(value);
+        if (key == "MemAvailable:") {
+            memAvailable = value;
         }
     }
 
     if (memTotal == 0 || memAvailable == 0) {
-        throw std::runtime_error("No se pudieron leer datos de memoria");
+        throw std::runtime_error(
+            "No se encontraron las claves MemTotal o MemAvailable en /proc/meminfo"
+        );
     }
 
-    return ((memTotal - memAvailable) * 100.0) / memTotal;
+    // Convertir de kB a bytes
+    memTotal     *= 1024;
+    memAvailable *= 1024;
+
+    // Calcular memoria usada: MemTotal - MemAvailable
+    long long memUsed = memTotal - memAvailable;
+
+    return {
+        static_cast<uint64_t>(memTotal),
+        static_cast<uint64_t>(memUsed),
+        static_cast<uint64_t>(memAvailable)
+    };
 }
+
+} // namespace pulso::collectors::memory

--- a/src/collectors/memory/ram_usage.hpp
+++ b/src/collectors/memory/ram_usage.hpp
@@ -1,3 +1,27 @@
 #pragma once
 
+#include <cstdint>
+
+namespace pulso::collectors::memory {
+
+/**
+ * @brief Contiene la informacion de uso de memoria RAM del sistema.
+ */
+struct RamInfo {
+    /** @brief Memoria total disponible en el sistema, expresada en bytes. */
+    uint64_t total;
+
+    /** @brief Memoria actualmente en uso, expresada en bytes. */
+    uint64_t used;
+
+    /** @brief Memoria disponible para ser utilizada, expresada en bytes. */
+    uint64_t available;
+};
+
+/**
+ * @brief Obtiene las metricas actuales de uso de memoria RAM del sistema.
+ * @return RamInfo con los valores de memoria total, usada y disponible.
+ */
 double getRAMUsage();
+
+} // namespace pulso::collectors::memory


### PR DESCRIPTION
## ¿Qué hace este PR?
Se corrige la implementación del método `getRamUsage()` dentro del componente de recolección de memoria (`ram_usage.cpp y `ram_usage.hpp`) para cumplir de forma estricta con los requisitos del contrato del sistema. 
## Issue relacionado
Closes #215 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica