### PR TITLE
Feat/endpoint prometheus 21

### DIFF
--- a/src/http/handler_prometheus.cpp
+++ b/src/http/handler_prometheus.cpp
@@ -1,0 +1,32 @@
+#include "http/handler_prometheus.hpp"
+#include "formatter/formatter_prometheus.hpp"
+
+#include <httplib.h>
+
+namespace pulso::http {
+
+void registrarPrometheus(
+    httplib::Server& servidor,
+    const pulso::storage::Storage& storage)
+{
+    servidor.Get("/metrics/prometheus",
+        [&storage](const httplib::Request& /*req*/, httplib::Response& res)
+        {
+            auto snapshot = storage.ultimo();
+
+            if (!snapshot) {
+                // Prometheus tolera respuestas vacías; devolvemos 200 con body vacío.
+                res.status = 200;
+                res.set_content("", "text/plain; version=0.0.4");
+                return;
+            }
+
+            pulso::formatter::FormatterPrometheus formatter;
+            std::string body = formatter.formatear(*snapshot);
+
+            res.status = 200;
+            res.set_content(body, "text/plain; version=0.0.4");
+        });
+}
+
+} // namespace pulso::http

--- a/src/http/handler_prometheus.hpp
+++ b/src/http/handler_prometheus.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <httplib.h>
+#include "storage/storage.hpp"
+
+namespace pulso::http {
+
+/// Registra el handler de /metrics/prometheus en el servidor httplib.
+void registrarPrometheus(
+    httplib::Server& servidor,
+    const pulso::storage::Storage& storage);
+
+} // namespace pulso::http


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa el endpoint `GET /metrics/prometheus` para exponer métricas en formato Prometheus text exposition format, permitiendo que un servidor Prometheus configure `pulso` como target de scraping.

Cambios 
- `src/http/handler_prometheus.hpp` — declara `registrarPrometheus`.
- `src/http/handler_prometheus.cpp` — implementa el handler: consulta el último snapshot vía `storage.ultimo()`, formatea con `FormatterPrometheus` y responde con `Content-Type: text/plain; version=0.0.4`.

Criterios de aceptación

- [x] `GET /metrics/prometheus` devuelve 200 con formato Prometheus correcto.
- [x] `Content-Type` es `text/plain; version=0.0.4`.
- [x] Sin datos en la base, responde 200 con body vacío.
- [x] Output válido según `promtool check metrics`.
- [x] No se modifican archivos fuera de los listados.

## Issue relacionado
Closes #101 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde