### PR TITLE
fix: agregar protección contra inclusión múltiple en headers

### DIFF
--- a/src/collectors/cpu/cpu_usage.hpp
+++ b/src/collectors/cpu/cpu_usage.hpp
@@ -1,5 +1,4 @@
-#ifndef CPU_USAGE_H
-#define CPU_USAGE_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -70,4 +69,3 @@ class CollectorCPU : public ICollector {
 };
  
 }  // namespace pulso::collectors
-#endif // CPU_USAGE_H


### PR DESCRIPTION
## ¿Qué hace este PR?
Se reemplazan los include guards tradicionales por #pragma once en cpu_usage.hpp, evitando inclusiones múltiples del header.

Archivo afectado
- src/collectors/cpu/cpu_usage.hpp

## Issue relacionado
Closes #227

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas