### PR TITLE
chore: eliminar referencia a archivos inexistentes en CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ target_sources(pulso PRIVATE
     utils/console_formatter.cpp
     utils/disk_usage.cpp
     utils/logging/logger.cpp
-    utils/ram_usage.cpp
     utils/signal_handler.cpp
 )
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Sanea el archivo `src/CMakeLists.txt` eliminando la referencia al archivo inexistente `utils/ram_usage.cpp`. Esto soluciona de raíz el error de configuración que bloqueaba el sistema de construcción con CMake, permitiendo que el proyecto vuelva a configurarse de manera limpia y consistente con el directorio físico actual.

## Issue relacionado
Closes #253

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="797" height="239" alt="image" src="https://github.com/user-attachments/assets/fdee2113-b83e-4e9b-a7d2-1cbc5aa4e8da" />

