### PR TITLE
Agrega pruebas unitarias para FormatterJSON

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -44,3 +44,13 @@ if(PULSO_BUILD_TESTS)
 
     FetchContent_MakeAvailable(googletest)
 endif()
+add_executable(test_formatter_json
+    tests/formatters/test_formatter_json.cpp
+)
+
+target_link_libraries(test_formatter_json
+    gtest
+    gtest_main
+)
+
+add_test(NAME test_formatter_json COMMAND test_formatter_json)

--- a/tests/formatters/test_formatter_json.cpp
+++ b/tests/formatters/test_formatter_json.cpp
@@ -1,0 +1,113 @@
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "formatters/formatter_json.hpp"
+#include "core/types.hpp"
+
+using json = nlohmann::json;
+
+static pulso::core::Snapshot crearSnapshot(std::int64_t timestamp) {
+    pulso::core::Snapshot s;
+    s.timestamp = timestamp;
+
+    pulso::core::Metrica m1;
+    m1.name = "cpu.usage";
+    m1.unit = "percent";
+    m1.value = 42.0;
+    m1.timestamp = timestamp;
+
+    pulso::core::Metrica m2;
+    m2.name = "memory.used";
+    m2.unit = "bytes";
+    m2.value = 2048.0;
+    m2.timestamp = timestamp;
+
+    s.metrics.push_back(m1);
+    s.metrics.push_back(m2);
+
+    return s;
+}
+
+TEST(TestFormatterJSON, Test_FormatoYContentType) {
+    pulso::formatters::FormatterJSON formatter;
+
+    EXPECT_EQ(formatter.formato(), "json");
+    EXPECT_EQ(formatter.contentType(), "application/json");
+}
+
+TEST(TestFormatterJSON, Test_SnapshotVacio) {
+    pulso::formatters::FormatterJSON formatter;
+
+    pulso::core::Snapshot snapshot;
+    snapshot.timestamp = 1000;
+
+    std::string output = formatter.formatear(snapshot);
+
+    json j = json::parse(output);
+
+    EXPECT_TRUE(j.contains("timestamp"));
+    EXPECT_TRUE(j.contains("metricas"));
+    EXPECT_TRUE(j["metricas"].is_array());
+    EXPECT_EQ(j["metricas"].size(), 0);
+}
+
+TEST(TestFormatterJSON, Test_SnapshotConMetricas) {
+    pulso::formatters::FormatterJSON formatter;
+
+    auto snapshot = crearSnapshot(2000);
+
+    std::string output = formatter.formatear(snapshot);
+
+    json j = json::parse(output);
+
+    ASSERT_EQ(j["metricas"].size(), 2);
+
+    EXPECT_EQ(j["metricas"][0]["name"], "cpu.usage");
+    EXPECT_EQ(j["metricas"][0]["unit"], "percent");
+
+    EXPECT_EQ(j["metricas"][1]["name"], "memory.used");
+    EXPECT_EQ(j["metricas"][1]["unit"], "bytes");
+}
+
+TEST(TestFormatterJSON, Test_HistorialVacio) {
+    pulso::formatters::FormatterJSON formatter;
+
+    std::vector<pulso::core::Snapshot> historial;
+
+    std::string output = formatter.formatearHistorial(historial);
+
+    json j = json::parse(output);
+
+    EXPECT_EQ(j["total"], 0);
+    EXPECT_TRUE(j["snapshots"].is_array());
+    EXPECT_EQ(j["snapshots"].size(), 0);
+}
+
+TEST(TestFormatterJSON, Test_HistorialConSnapshots) {
+    pulso::formatters::FormatterJSON formatter;
+
+    std::vector<pulso::core::Snapshot> historial;
+
+    historial.push_back(crearSnapshot(100));
+    historial.push_back(crearSnapshot(200));
+    historial.push_back(crearSnapshot(300));
+
+    std::string output = formatter.formatearHistorial(historial);
+
+    json j = json::parse(output);
+
+    EXPECT_EQ(j["total"], 3);
+    EXPECT_EQ(j["snapshots"].size(), 3);
+}
+
+TEST(TestFormatterJSON, Test_OutputEsParseable) {
+    pulso::formatters::FormatterJSON formatter;
+
+    auto snapshot = crearSnapshot(5000);
+
+    std::string output = formatter.formatear(snapshot);
+
+    EXPECT_NO_THROW({
+        json::parse(output);
+    });
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para `FormatterJSON` verificando:

- formato y content type
- serialización de snapshots vacíos
- serialización de snapshots con métricas
- serialización de historiales vacíos
- serialización de historiales con snapshots
- que el JSON generado sea parseable correctamente

También se agrega el registro del nuevo test en la configuración de CMake.

## Issue relacionado
Closes #104

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Se agregó:
- `tests/formatters/test_formatter_json.cpp`

Y se actualizó:
- `cmake/Dependencies.cmake`

para registrar el nuevo test.
<img width="781" height="308" alt="imagen_2026-05-28_215106858" src="https://github.com/user-attachments/assets/b4ef885d-5a2a-43f6-b87e-08d9541bb753" />
<img width="790" height="845" alt="imagen_2026-05-28_215152943" src="https://github.com/user-attachments/assets/730a41fa-2885-494f-a066-69914e43b6c9" />

