### PR TITLE
fix: agregar include guards con patrón PULSO_CPU_CPU_USAGE_HPP

### DIFF
--- a/src/collectors/cpu/cpu_usage.hpp
+++ b/src/collectors/cpu/cpu_usage.hpp
@@ -1,5 +1,5 @@
-#ifndef CPU_USAGE_H
-#define CPU_USAGE_H
+#ifndef PULSO_CPU_CPU_USAGE_HPP
+#define PULSO_CPU_CPU_USAGE_HPP
 
 #include <cstdint>
 #include <string>
@@ -70,4 +70,4 @@ class CollectorCPU : public ICollector {
 };
  
 }  // namespace pulso::collectors
-#endif // CPU_USAGE_H
+#endif // PULSO_CPU_CPU_USAGE_HPP


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega protección contra inclusión múltiple en `cpu_usage.hpp` siguiendo el patrón `PULSO_MODULO_NOMBRE_HPP` requerido en el Issue #227.

## Cambios realizados

- `src/collectors/cpu/cpu_usage.hpp`: reemplaza `CPU_USAGE_H` por `PULSO_CPU_CPU_USAGE_HPP`

## Archivos verificados (ya tenían protección, no requieren cambios)

| Archivo | Protección actual |
|---------|-----------------|
| `src/core/types.hpp` | `#pragma once` |
| `src/collectors/memory/ram_usage.hpp` | `#pragma once` |
| `src/storage/schema.hpp` | `#pragma once` |

## Issue relacionado
Closes #227

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas