### PR TITLE
feat(http): implementar endpoint /metrics

### DIFF
--- a/src/http/handler_metrics.cpp
+++ b/src/http/handler_metrics.cpp
@@ -1,0 +1,50 @@
+#include "handler_metrics.hpp"
+#include "utils/logging/logger.hpp"
+
+#include <string>
+
+namespace pulso::http {
+
+void registrarMetrics(
+    httplib::Server&                       servidor,
+    const pulso::storage::Storage&         storage,
+    const pulso::formatters::IFormatter&   formatter)
+{
+    servidor.Get("/metrics", [&storage, &formatter](
+        const httplib::Request&  req,
+        httplib::Response&       res)
+    {
+        auto& logger = pulso::utils::logging::Logger::instancia();
+
+        // Obtener el snapshot más reciente
+        auto snapshot = storage.last();
+
+        int statusCode = 0;
+
+        if (snapshot.has_value()) {
+            // Hay datos: responder con 200 y el body del formatter
+            std::string body        = formatter.formatear(snapshot.value());
+            std::string contentType = formatter.contentType();
+
+            res.set_content(body, contentType);
+            res.status = 200;
+            statusCode = 200;
+        } else {
+            // No hay datos: responder con 503
+            res.set_content(
+                R"({ "error": "sin datos disponibles" })",
+                "application/json"
+            );
+            res.status = 503;
+            statusCode = 503;
+        }
+
+        // Registrar la request en el log con nivel INFO
+        logger.info(
+            req.method + " " + req.path +
+            " -> " + std::to_string(statusCode)
+        );
+    });
+}
+
+} // namespace pulso::http

--- a/src/http/handler_metrics.hpp
+++ b/src/http/handler_metrics.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <httplib.h>
+#include "storage/storage.hpp"
+#include "formatters/iformatter.hpp"
+
+namespace pulso::http {
+
+/**
+ * @brief Registra el handler del endpoint GET /metrics en el servidor HTTP.
+ *
+ * El handler devuelve el snapshot más reciente almacenado en la base de datos,
+ * formateado según el formatter proporcionado.
+ *
+ * - Si hay datos: responde con HTTP 200 y el body producido por el formatter.
+ * - Si no hay datos: responde con HTTP 503 y un JSON de error.
+ *
+ * Cada request se registra en el log con nivel INFO incluyendo
+ * método, ruta y código de respuesta.
+ *
+ * @param servidor  Referencia al servidor httplib donde se registra el handler.
+ * @param storage   Referencia al almacenamiento para obtener el último snapshot.
+ * @param formatter Referencia al formatter que serializa el snapshot.
+ */
+void registrarMetrics(
+    httplib::Server&                       servidor,
+    const pulso::storage::Storage&         storage,
+    const pulso::formatters::IFormatter&   formatter);
+
+} // namespace pulso::http


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea los archivos src/http/handler_metrics.hpp y src/http/handler_metrics.cpp con la implementación del endpoint GET /metrics. Responde con HTTP 200 y el body formateado por IFormatter cuando hay datos disponibles, o con HTTP 503 
y un JSON de error cuando la base está vacía. Cada request se registra en el log con nivel INFO incluyendo método, ruta y código de respuesta.

## Issue relacionado
Closes #99 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/d5635e6c-ecc1-4d1b-a845-84928c42f4ac" />
<img width="1364" height="762" alt="image" src="https://github.com/user-attachments/assets/df32e31a-4c01-459c-b5c3-8e71d2f0b60f" />
