### PR TITLE
feat: implementar CollectorMemory para Linux

### DIFF
--- a/src/platform/linux/collector_memory.cpp
+++ b/src/platform/linux/collector_memory.cpp
@@ -1,0 +1,76 @@
+#include "collector_memory.hpp"
+#include "../../collectors/error_recoleccion.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace pulso::collectors {
+
+std::string CollectorMemory::nombre() const {
+    return "memory";
+}
+
+std::vector<pulso::core::Metrica> CollectorMemory::recolectar() {
+    std::ifstream file("/proc/meminfo");
+
+    if (!file.is_open()) {
+        throw ErrorRecoleccion("No se pudo abrir /proc/meminfo");
+    }
+
+    long long memTotalKB = -1;
+    long long memAvailableKB = -1;
+    long long memFreeKB = -1;
+
+    std::string key;
+    long long value;
+    std::string unit;
+
+    while (file >> key >> value >> unit) {
+        if (key == "MemTotal:") {
+            memTotalKB = value;
+        } else if (key == "MemAvailable:") {
+            memAvailableKB = value;
+        } else if (key == "MemFree:") {
+            memFreeKB = value;
+        }
+    }
+
+    if (memTotalKB < 0 || memAvailableKB < 0 || memFreeKB < 0) {
+        throw ErrorRecoleccion(
+            "No se encontraron las claves requeridas en /proc/meminfo"
+        );
+    }
+
+    const double memTotalBytes =
+        static_cast<double>(memTotalKB) * 1024.0;
+
+    const double memAvailableBytes =
+        static_cast<double>(memAvailableKB) * 1024.0;
+
+    const double memUsedBytes =
+        static_cast<double>(memTotalKB - memAvailableKB) * 1024.0;
+
+    return {
+        pulso::core::Metrica{
+            "memory.total",
+            memTotalBytes,
+            "bytes",
+            0
+        },
+        pulso::core::Metrica{
+            "memory.used",
+            memUsedBytes,
+            "bytes",
+            0
+        },
+        pulso::core::Metrica{
+            "memory.available",
+            memAvailableBytes,
+            "bytes",
+            0
+        }
+    };
+}
+
+} // namespace pulso::collectors

--- a/src/platform/linux/collector_memory.hpp
+++ b/src/platform/linux/collector_memory.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "../../collectors/icollector.hpp"
+#include <vector>
+#include <string>
+
+namespace pulso::collectors {
+
+class CollectorMemory : public ICollector {
+public:
+    std::string nombre() const override;
+    std::vector<pulso::core::Metrica> recolectar() override;
+};
+
+} // namespace pulso::collectors


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa el collector de memoria para Linux mediante la clase `CollectorMemory`, que obtiene información desde `/proc/meminfo`.

La implementación:

- Lee las claves `MemTotal`, `MemAvailable` y `MemFree`.
- Convierte los valores de kB a bytes.
- Calcula `memory.used` como `MemTotal - MemAvailable`.
- Expone las métricas:
  - `memory.total`
  - `memory.used`
  - `memory.available`
- Lanza `ErrorRecoleccion` cuando `/proc/meminfo` no es accesible o faltan las claves requeridas.

## Issue relacionado
Closes #93 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Archivos agregados:

- `src/platform/linux/collector_memory.hpp`
- `src/platform/linux/collector_memory.cpp`

Se verificó que el collector:

- Hereda de `ICollector`.
- Retorna `"memory"` desde `nombre()`.
- Devuelve las métricas `memory.total`, `memory.used` y `memory.available`.
- Convierte correctamente los valores de `/proc/meminfo` de kB a bytes.
- Lanza `ErrorRecoleccion` ante errores de acceso o parseo.