### PR TITLE
feat(utils): implementar logger con niveles DEBUG/INFO/WARN/ERROR #275

### DIFF
--- a/src/utils/logging/logger.cpp
+++ b/src/utils/logging/logger.cpp
@@ -13,34 +13,33 @@ namespace {
 std::string obtenerTimestamp() {
     auto ahora = std::chrono::system_clock::now();
     std::time_t tiempo = std::chrono::system_clock::to_time_t(ahora);
-
     std::tm tiempoLocal{};
-
 #ifdef _WIN32
     localtime_s(&tiempoLocal, &tiempo);
 #else
     localtime_r(&tiempo, &tiempoLocal);
 #endif
-
     std::ostringstream oss;
     oss << std::put_time(&tiempoLocal, "%Y-%m-%d %H:%M:%S");
-
     return oss.str();
 }
 
-std::string nivelATexto(Nivel nivel) {
+std::string nivelATexto(LogLevel nivel) {
     switch (nivel) {
-        case Nivel::DEBUG:
-            return "DEBUG";
-        case Nivel::INFO:
-            return "INFO";
-        case Nivel::WARN:
-            return "WARN";
-        case Nivel::ERROR:
-            return "ERROR";
-        default:
-            return "UNKNOWN";
+        case LogLevel::DEBUG: return "DEBUG";
+        case LogLevel::INFO:  return "INFO";
+        case LogLevel::WARN:  return "WARN";
+        case LogLevel::ERROR: return "ERROR";
+        default:              return "UNKNOWN";
     }
+}
+
+void imprimir(const std::mutex& mutex_, LogLevel nivel, LogLevel minimo, const std::string& mensaje) {
+    if (nivel < minimo) return;
+    std::lock_guard<std::mutex> lock(const_cast<std::mutex&>(mutex_));
+    std::cerr << "[" << obtenerTimestamp() << "] "
+              << "[" << nivelATexto(nivel) << "] "
+              << mensaje << '\n';
 }
 
 } // namespace
@@ -50,56 +49,24 @@ Logger& Logger::instancia() {
     return instancia;
 }
 
-void Logger::configurar(Nivel nivelMinimo) {
-    nivelMinimo_ = nivelMinimo;
+void Logger::setMinLevel(LogLevel nivel) {
+    nivelMinimo_ = nivel;
 }
 
 void Logger::debug(const std::string& mensaje) {
-    if (Nivel::DEBUG < nivelMinimo_) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    std::cerr << "[" << obtenerTimestamp() << "] "
-              << "[DEBUG] "
-              << mensaje << '\n';
+    imprimir(mutex_, LogLevel::DEBUG, nivelMinimo_, mensaje);
 }
 
 void Logger::info(const std::string& mensaje) {
-    if (Nivel::INFO < nivelMinimo_) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    std::cerr << "[" << obtenerTimestamp() << "] "
-              << "[INFO] "
-              << mensaje << '\n';
+    imprimir(mutex_, LogLevel::INFO, nivelMinimo_, mensaje);
 }
 
 void Logger::warn(const std::string& mensaje) {
-    if (Nivel::WARN < nivelMinimo_) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    std::cerr << "[" << obtenerTimestamp() << "] "
-              << "[WARN] "
-              << mensaje << '\n';
+    imprimir(mutex_, LogLevel::WARN, nivelMinimo_, mensaje);
 }
 
 void Logger::error(const std::string& mensaje) {
-    if (Nivel::ERROR < nivelMinimo_) {
-        return;
-    }
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    std::cerr << "[" << obtenerTimestamp() << "] "
-              << "[ERROR] "
-              << mensaje << '\n';
+    imprimir(mutex_, LogLevel::ERROR, nivelMinimo_, mensaje);
 }
 
 } // namespace pulso::utils::logging

--- a/src/utils/logging/logger.hpp
+++ b/src/utils/logging/logger.hpp
@@ -5,13 +5,31 @@
 
 namespace pulso::utils::logging {
 
-enum class Nivel { DEBUG, INFO, WARN, ERROR };
+/**
+ * @brief Niveles de log disponibles para el Logger.
+ * DEBUG=0, INFO=1, WARN=2, ERROR=3
+ */
+enum class LogLevel {
+    DEBUG = 0,
+    INFO  = 1,
+    WARN  = 2,
+    ERROR = 3
+};
 
+/**
+ * @brief Logger singleton con soporte para niveles configurables.
+ * Por defecto el nivel mínimo es INFO.
+ */
 class Logger {
 public:
     static Logger& instancia();
 
-    void configurar(Nivel nivelMinimo);
+    /**
+     * @brief Establece el nivel mínimo de log.
+     * Mensajes por debajo de este nivel no se imprimen.
+     * @param nivel Nivel mínimo deseado.
+     */
+    void setMinLevel(LogLevel nivel);
 
     void debug(const std::string& mensaje);
     void info(const std::string& mensaje);
@@ -20,8 +38,7 @@ public:
 
 private:
     Logger() = default;
-
-    Nivel nivelMinimo_ = Nivel::INFO;
+    LogLevel nivelMinimo_ = LogLevel::INFO;
     std::mutex mutex_;
 };
 


### PR DESCRIPTION

## ¿Qué hace este PR?
Modifica logger.hpp y logger.cpp para agregar enum LogLevel con
DEBUG=0, INFO=1, WARN=2, ERROR=3 y método setMinLevel() que filtra
mensajes por debajo del nivel mínimo. Cada mensaje incluye timestamp
y prefijo de nivel. Nivel por defecto es INFO.


## Issue relacionado
Closes #275

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica