### PR TITLE
feat(http): implementar handler_health — endpoint GET /health para health-check del agente #271

### DIFF
--- a/src/http/handler_health.cpp
+++ b/src/http/handler_health.cpp
@@ -1,21 +1,42 @@
 #include "handler_health.hpp"
 
+#include <chrono>
+#include <sstream>
+#include <string>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <unistd.h>
+#endif
+
 namespace pulso::http {
 
-void registrarHealth(httplib::Server& servidor) {
-    servidor.Get("/health", [](const httplib::Request&, httplib::Response& res) {
+static const std::string VERSION = "0.1.0";
 
-        res.set_content(
-            R"({
-  "status": "ok",
-  "service": "pulso",
-  "version": "0.1.0"
-})",
-            "application/json"
-        );
+std::string handleHealth(std::chrono::steady_clock::time_point start_time) {
 
-        res.status = 200;
-    });
+    // Calcular uptime en segundos
+    auto ahora   = std::chrono::steady_clock::now();
+    auto uptime  = std::chrono::duration_cast<std::chrono::seconds>(
+                       ahora - start_time).count();
+
+    // Obtener hostname
+    char hostname[256];
+    if (gethostname(hostname, sizeof(hostname)) != 0) {
+        std::string(hostname, sizeof(hostname)) = "unknown";
+    }
+
+    // Construir JSON
+    std::ostringstream json;
+    json << "{"
+         << "\"status\":\"ok\","
+         << "\"uptime_seconds\":" << uptime << ","
+         << "\"version\":\"" << VERSION << "\","
+         << "\"hostname\":\"" << hostname << "\""
+         << "}";
+
+    return json.str();
 }
 
 } // namespace pulso::http

--- a/src/http/handler_health.hpp
+++ b/src/http/handler_health.hpp
@@ -1,10 +1,22 @@
 #pragma once
 
-#include <httplib.h>
+#include <chrono>
+#include <string>
 
 namespace pulso::http {
 
-/// Registra el handler de /health en el servidor httplib.
-void registrarHealth(httplib::Server& servidor);
+/**
+ * @brief Genera una respuesta JSON para el endpoint GET /health.
+ *
+ * Retorna un JSON con:
+ * - status: siempre "ok"
+ * - uptime_seconds: segundos transcurridos desde start_time
+ * - version: versión hardcodeada "0.1.0"
+ * - hostname: nombre real de la máquina
+ *
+ * @param start_time Punto en el tiempo cuando el agente inició.
+ * @return std::string JSON con la información de health-check.
+ */
+std::string handleHealth(std::chrono::steady_clock::time_point start_time);
 
 } // namespace pulso::http


### PR DESCRIPTION

## ¿Qué hace este PR?
Crea handler_health.hpp y handler_health.cpp con la función
handleHealth() que retorna JSON con status "ok", uptime_seconds
basado en start_time, version "0.1.0" hardcodeada y hostname
real de la máquina usando gethostname().

## Issue relacionado
Closes #271

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica