### PR TITLE
feat(formatters): implementar FormatterCSV — exportar métricas en formato CSV con cabecera #269

### DIFF
--- a/src/formatters/formatter_csv.cpp
+++ b/src/formatters/formatter_csv.cpp
@@ -1,0 +1,81 @@
+#include "formatter_csv.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+namespace pulso::formatters {
+
+static const std::string CABECERA =
+    "timestamp,cpu_pct,ram_used_mb,ram_total_mb,"
+    "disk_used_gb,disk_total_gb,net_rx_kb,net_tx_kb";
+
+std::string FormatterCSV::formato() const {
+    return "csv";
+}
+
+std::string FormatterCSV::contentType() const {
+    return "text/csv";
+}
+
+std::string FormatterCSV::cabecera() {
+    return CABECERA + "\n";
+}
+
+std::string FormatterCSV::filaDeSnapshot(const pulso::core::Snapshot& snapshot) {
+    double cpu_pct      = 0.0;
+    double ram_used_mb  = 0.0;
+    double ram_total_mb = 0.0;
+    double disk_used_gb = 0.0;
+    double disk_total_gb= 0.0;
+    double net_rx_kb    = 0.0;
+    double net_tx_kb    = 0.0;
+
+    for (const auto& m : snapshot.metricas) {
+        if (m.nombre == "cpu.usage")        cpu_pct      = m.valor;
+        else if (m.nombre == "ram.used")    ram_used_mb  = m.valor / (1024.0 * 1024.0);
+        else if (m.nombre == "ram.total")   ram_total_mb = m.valor / (1024.0 * 1024.0);
+        else if (m.nombre == "disk.used")   disk_used_gb = m.valor / (1024.0 * 1024.0 * 1024.0);
+        else if (m.nombre == "disk.total")  disk_total_gb= m.valor / (1024.0 * 1024.0 * 1024.0);
+        else if (m.nombre == "net.rx")      net_rx_kb    = m.valor / 1024.0;
+        else if (m.nombre == "net.tx")      net_tx_kb    = m.valor / 1024.0;
+    }
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+    oss << snapshot.timestamp << ","
+        << cpu_pct      << ","
+        << ram_used_mb  << ","
+        << ram_total_mb << ","
+        << disk_used_gb << ","
+        << disk_total_gb<< ","
+        << net_rx_kb    << ","
+        << net_tx_kb    << "\n";
+
+    return oss.str();
+}
+
+std::string FormatterCSV::formatear(const pulso::core::Snapshot& snapshot) const {
+    std::string resultado;
+
+    if (!cabecераEmitida_) {
+        resultado += cabecera();
+        cabecераEmitida_ = true;
+    }
+
+    resultado += filaDeSnapshot(snapshot);
+    return resultado;
+}
+
+std::string FormatterCSV::formatearHistorial(
+    const std::vector<pulso::core::Snapshot>& snapshots) const {
+
+    std::string resultado = cabecera();
+
+    for (const auto& snapshot : snapshots) {
+        resultado += filaDeSnapshot(snapshot);
+    }
+
+    return resultado;
+}
+
+} // namespace pulso::formatters

--- a/src/formatters/formatter_csv.hpp
+++ b/src/formatters/formatter_csv.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "iformatter.hpp"
+#include <string>
+#include <vector>
+
+namespace pulso::formatters {
+
+/**
+ * @brief Formateador de métricas en formato CSV.
+ *
+ * La primera llamada a formatear() emite la línea de cabecera.
+ * Las llamadas siguientes emiten filas de datos separadas por comas.
+ * Los valores flotantes se presentan con 2 decimales.
+ */
+class FormatterCSV : public IFormatter {
+public:
+    /**
+     * @brief Retorna el identificador del formato.
+     * @return "csv"
+     */
+    std::string formato() const override;
+
+    /**
+     * @brief Retorna el Content-Type HTTP asociado.
+     * @return "text/csv"
+     */
+    std::string contentType() const override;
+
+    /**
+     * @brief Serializa un único snapshot en formato CSV.
+     * La primera llamada incluye la cabecera.
+     * @param snapshot El snapshot a serializar.
+     * @return Cadena CSV con cabecera o fila de datos.
+     */
+    std::string formatear(const pulso::core::Snapshot& snapshot) const override;
+
+    /**
+     * @brief Serializa una lista de snapshots en formato CSV.
+     * Incluye cabecera en la primera línea.
+     * @param snapshots Vector de snapshots a serializar.
+     * @return Cadena CSV completa con cabecera y filas de datos.
+     */
+    std::string formatearHistorial(
+        const std::vector<pulso::core::Snapshot>& snapshots) const override;
+
+private:
+    mutable bool cabecераEmitida_ = false;
+
+    static std::string cabecera();
+    static std::string filaDeSnapshot(const pulso::core::Snapshot& snapshot);
+};
+
+} // namespace pulso::formatters


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea formatter_csv.hpp y formatter_csv.cpp con la clase FormatterCSV
que hereda de IFormatter. La primera llamada a formatear() emite
cabecera con timestamp,cpu_pct,ram_used_mb,ram_total_mb,disk_used_gb,
disk_total_gb,net_rx_kb,net_tx_kb. Las siguientes emiten filas de datos
con comas como separador y floats con 2 decimales.

## Issue relacionado
Closes #269

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica