### PR TITLE
test: pruebas unitarias para getDiskUsage — verificar consistencia total/used/free

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,3 +42,14 @@ target_link_libraries(test_storage PRIVATE
     dl
 )
 gtest_discover_tests(test_storage)
+add_executable(test_disk_usage
+    automatizados/test_disk_usage.cpp
+)
+target_include_directories(test_disk_usage PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test_disk_usage PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+)
+gtest_discover_tests(test_disk_usage)

--- a/tests/automatizados/test_disk_usage.cpp
+++ b/tests/automatizados/test_disk_usage.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "collectors/disk/disk_usage.cpp"
+
+namespace {
+
+// Tolerancia de 1 MB para la verificación de consistencia
+constexpr uint64_t TOLERANCIA = 1048576;
+
+/**
+ * @brief Verifica que el espacio total del disco es mayor a cero.
+ */
+TEST(DiskUsageTest, TotalEsMayorACero) {
+    DiskUsage uso = getDiskUsage();
+    ASSERT_GT(uso.total, static_cast<uint64_t>(0));
+}
+
+/**
+ * @brief Verifica que el espacio libre no es negativo.
+ */
+TEST(DiskUsageTest, LibreNoEsNegativo) {
+    DiskUsage uso = getDiskUsage();
+    ASSERT_GE(uso.libre, static_cast<uint64_t>(0));
+}
+
+/**
+ * @brief Verifica que el espacio usado no es negativo.
+ */
+TEST(DiskUsageTest, UsadoNoEsNegativo) {
+    DiskUsage uso = getDiskUsage();
+    ASSERT_GE(uso.usado, static_cast<uint64_t>(0));
+}
+
+/**
+ * @brief Verifica que usado + libre no supera total más la tolerancia de 1 MB.
+ */
+TEST(DiskUsageTest, ConsistenciaUsadoMasLibre) {
+    DiskUsage uso = getDiskUsage();
+    ASSERT_LE(uso.usado + uso.libre, uso.total + TOLERANCIA);
+}
+
+} // namespace


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea tests/automatizados/test_disk_usage.cpp con 4 pruebas unitarias para getDiskUsage() usando Google Test. Verifica que total > 0, libre >= 0, usado >= 0 y que usado + libre <= total + 1 MB de tolerancia. 
Se actualiza tests/CMakeLists.txt agregando el target test_disk_usage.
Los 4 tests pasan correctamente.

## Issue relacionado
Closes #159 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="1002" height="475" alt="image" src="https://github.com/user-attachments/assets/e38d6f13-264f-4a4e-9daf-b2a727d0f9c0" />
