### PR TITLE
feat(storage): implementar método getPromedio en storage.cpp — promedio de métricas en ventana de tiempo

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -1,5 +1,7 @@
 #include "storage.hpp"
 #include "schema.hpp"
+#include <ctime>
+#include <map>
  
 namespace pulso::storage {
  
@@ -125,6 +127,59 @@ std::size_t Storage::total() const {
     query.executeStep();
     return static_cast<std::size_t>(query.getColumn(0).getInt64());
 }
- 
+pulso::core::Snapshot Storage::getPromedio(uint32_t ventana_segundos) const {
+    // Calcular el timestamp de inicio de la ventana
+    std::int64_t ahora = static_cast<std::int64_t>(std::time(nullptr));
+    std::int64_t desde = ahora - static_cast<std::int64_t>(ventana_segundos);
+
+    // Obtener snapshots dentro de la ventana
+    auto snapshots = history(desde, ahora);
+
+    // Si no hay snapshots en la ventana, retornar snapshot vacío
+    if (snapshots.empty()) {
+        pulso::core::Snapshot vacio;
+        vacio.timestamp = ahora;
+        for (const auto& nombre : {
+            "cpu.usage", "cpu.cores",
+            "memory.total", "memory.used", "memory.available",
+            "disk.total", "disk.used", "disk.free",
+            "network.rx_bytes", "network.tx_bytes"}) {
+            pulso::core::Metrica m;
+            m.name      = nombre;
+            m.value     = 0.0;
+            m.unit      = "";
+            m.timestamp = ahora;
+            vacio.metrics.push_back(m);
+        }
+        return vacio;
+    }
+
+    // Acumular valores por nombre de métrica
+    std::map<std::string, double> acumulado;
+    std::map<std::string, std::string> unidades;
+
+    for (const auto& snap : snapshots) {
+        for (const auto& m : snap.metrics) {
+            acumulado[m.name] += m.value;
+            unidades[m.name]   = m.unit;
+        }
+    }
+
+    // Calcular promedio
+    pulso::core::Snapshot promedio;
+    promedio.timestamp = ahora;
+
+    for (auto& [nombre, total] : acumulado) {
+        pulso::core::Metrica m;
+        m.name      = nombre;
+        m.value     = total / static_cast<double>(snapshots.size());
+        m.unit      = unidades[nombre];
+        m.timestamp = ahora;
+        promedio.metrics.push_back(m);
+    }
+
+    return promedio;
+}
+
 } // namespace pulso::storage
  

--- a/src/storage/storage.hpp
+++ b/src/storage/storage.hpp
@@ -58,6 +58,17 @@ public:
      * @return Cantidad total de snapshots.
      */
     std::size_t total() const;
+    /**
+    * @brief Calcula el promedio de las métricas en una ventana de tiempo.
+    *
+    * Promedia todos los snapshots cuyo timestamp esté dentro de los últimos
+    * ventana_segundos. Si no hay snapshots en la ventana, retorna un snapshot
+    * con todos los campos en 0.
+    *
+    * @param ventana_segundos Tamaño de la ventana en segundos.
+    * @return Snapshot con los valores promediados.
+    */
+    pulso::core::Snapshot getPromedio(uint32_t ventana_segundos) const;
  
 private:
     SQLite::Database db_;


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el método ```getPromedio(uint32_t ventana_segundos)``` a la clase Storage en ```src/storage/storage.hpp``` y ```src/storage/storage.cpp```. El método calcula el promedio de todas las métricas de los snapshots cuyo timestamp esté dentro 
de la ventana de tiempo indicada. Si no hay snapshots en la ventana, retorna un snapshot con todos los campos en 0.0.

## Issue relacionado
Closes #284 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="981" height="513" alt="image" src="https://github.com/user-attachments/assets/dd4be065-326e-4646-ae68-cfff9235d966" />
