### PR TITLE
feat(core): implementar AlertaUmbral — disparar alerta cuando una métrica supera un umbral configurable - Closes #274

### DIFF
--- a/src/alertas/alerta_umbral.cpp
+++ b/src/alertas/alerta_umbral.cpp
@@ -1,0 +1,56 @@
+#include "alerta_umbral.hpp"
+#include <stdexcept>
+#include <string>
+
+namespace pulso::alertas {
+
+AlertaUmbral::AlertaUmbral(const std::string& metrica, float umbral, char operador)
+    : metrica_(metrica), umbral_(umbral), operador_(operador)
+{
+    if (operador_ != '>' && operador_ != '<') {
+        throw std::invalid_argument(
+            "Operador no válido: '" + std::string(1, operador_) +
+            "'. Use '>' o '<'."
+        );
+    }
+}
+
+bool AlertaUmbral::evaluar(const pulso::MetricSnapshot& snap) const {
+    double valor = 0.0;
+    bool encontrado = true;
+
+    // Mapear el nombre de la métrica a su campo en MetricSnapshot
+    if (metrica_ == "cpu" || metrica_ == "cpu.usage_pct") {
+        valor = snap.cpu;
+    } else if (metrica_ == "ram") {
+        valor = snap.ram;
+    } else if (metrica_ == "disk") {
+        valor = snap.disk;
+    } else if (metrica_ == "rx_bytes") {
+        valor = snap.rx_bytes;
+    } else if (metrica_ == "tx_bytes") {
+        valor = snap.tx_bytes;
+    } else {
+        encontrado = false;
+    }
+
+    if (!encontrado) {
+        throw std::invalid_argument(
+            "Métrica desconocida: '" + metrica_ + "'. "
+            "Métricas válidas: cpu, cpu.usage_pct, ram, disk, rx_bytes, tx_bytes."
+        );
+    }
+
+    if (operador_ == '>') {
+        return valor > static_cast<double>(umbral_);
+    } else {
+        return valor < static_cast<double>(umbral_);
+    }
+}
+
+std::string AlertaUmbral::mensaje() const {
+    return "Alerta: " + metrica_ + " " + operador_ +
+           " " + std::to_string(umbral_);
+}
+
+} // namespace pulso::alertas

--- a/src/alertas/alerta_umbral.hpp
+++ b/src/alertas/alerta_umbral.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <string>
+#include <stdexcept>
+#include "../core/MetricSnapshot.hpp"
+
+namespace pulso::alertas {
+
+/**
+ * @brief Alerta que se dispara cuando una métrica supera un umbral configurable.
+ *
+ * Evalúa una métrica del snapshot contra un umbral numérico usando un operador
+ * de comparación ('>' o '<'). Si la condición se cumple, la alerta está activa.
+ */
+class AlertaUmbral {
+public:
+    /**
+     * @brief Construye una alerta de umbral.
+     * @param metrica  Nombre de la métrica a evaluar (ej: "cpu.usage_pct", "ram").
+     * @param umbral   Valor de referencia contra el cual comparar.
+     * @param operador Operador de comparación: '>' o '<'.
+     * @throws std::invalid_argument si el operador no es '>' ni '<'.
+     */
+    AlertaUmbral(const std::string& metrica, float umbral, char operador);
+
+    /**
+     * @brief Evalúa si la condición de alerta se cumple en el snapshot dado.
+     * @param snap Snapshot con las métricas actuales del sistema.
+     * @return true si la métrica supera el umbral según el operador configurado.
+     * @throws std::invalid_argument si la métrica no existe en el snapshot.
+     */
+    bool evaluar(const pulso::MetricSnapshot& snap) const;
+
+    /**
+     * @brief Devuelve un mensaje descriptivo sobre la alerta.
+     * @return Cadena con el nombre de la métrica, el operador y el umbral.
+     */
+    std::string mensaje() const;
+
+private:
+    std::string metrica_;  ///< Nombre de la métrica a evaluar
+    float       umbral_;   ///< Valor umbral de referencia
+    char        operador_; ///< Operador de comparación: '>' o '<'
+};
+
+} // namespace pulso::alertas


### PR DESCRIPTION
## ¿Qué hace este PR?
Se añade el componente de control y monitorización de métricas del sistema mediante la implementación de la clase `AlertaUmbral`. Este módulo actúa de forma directa sobre los snapshots del sistema, evaluando si el rendimiento de un recurso específico excede los límites operacionales configurados.

## Issue relacionado
Closes #274 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="753" height="492" alt="image" src="https://github.com/user-attachments/assets/76869cfe-7777-4fb9-bdee-d232580e02ed" />
<img width="863" height="586" alt="image" src="https://github.com/user-attachments/assets/ffb88b07-c776-47f5-9010-641b7216d2af" />


