### PR TITLE
feat(collectors): implement process collector using /proc/stat and /proc/loadavg - Closes #267

### DIFF
--- a/src/collectors/procesos/proc_collector.cpp
+++ b/src/collectors/procesos/proc_collector.cpp
@@ -1,0 +1,86 @@
+#include "proc_collector.h"
+#include <string>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace pulso::collectors {
+
+ProcInfo getProcInfo() {
+    ProcInfo info{};
+
+    // =========================
+    // Leer /proc/stat
+    // =========================
+    std::ifstream statFile("/proc/stat");
+
+    if (!statFile.is_open()) {
+        throw std::runtime_error(
+            "No se pudo abrir /proc/stat para leer información de procesos."
+        );
+    }
+
+    std::string line;
+
+    while (std::getline(statFile, line)) {
+        std::istringstream iss(line);
+        std::string key;
+        uint32_t value;
+
+        iss >> key >> value;
+
+        if (key == "procs_running") {
+            info.running = value;
+        } else if (key == "procs_blocked") {
+            info.blocked = value;
+        }
+    }
+
+    statFile.close();
+
+    // =========================
+    // Leer /proc/loadavg
+    // =========================
+    std::ifstream loadavgFile("/proc/loadavg");
+
+    if (!loadavgFile.is_open()) {
+        throw std::runtime_error(
+            "No se pudo abrir /proc/loadavg para leer el total de procesos."
+        );
+    }
+
+    std::string load1;
+    std::string load5;
+    std::string load15;
+    std::string procesos;
+
+    loadavgFile >> load1 >> load5 >> load15 >> procesos;
+
+    loadavgFile.close();
+
+    const std::size_t separator = procesos.find('/');
+
+    if (separator == std::string::npos) {
+        throw std::runtime_error(
+            "Formato inválido en /proc/loadavg: no se encontró 'activos/total'."
+        );
+    }
+
+    const std::string totalStr = procesos.substr(separator + 1);
+
+    try {
+        info.total = static_cast<uint32_t>(std::stoul(totalStr));
+    } catch (const std::exception&) {
+        throw std::runtime_error(
+            "No se pudo convertir el total de procesos desde /proc/loadavg."
+        );
+    }
+
+    if (info.running > info.total) {
+        info.running = info.total;
+    }
+
+    return info;
+}
+
+} // namespace pulso::collectors

--- a/src/collectors/procesos/proc_collector.h
+++ b/src/collectors/procesos/proc_collector.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstdint>
+
+namespace pulso::collectors {
+
+/**
+ * @brief Información de procesos obtenida desde /proc.
+ */
+struct ProcInfo {
+    uint32_t running{}; ///< Procesos actualmente en ejecución
+    uint32_t blocked{}; ///< Procesos bloqueados esperando I/O
+    uint32_t total{};   ///< Total de procesos del sistema
+};
+
+/**
+ * @brief Obtiene estadísticas de procesos desde /proc/stat y /proc/loadavg.
+ *
+ * Lee:
+ * - /proc/stat:
+ *   - procs_running
+ *   - procs_blocked
+ *
+ * - /proc/loadavg:
+ *   - campo activos/total (4to campo)
+ *
+ * @return ProcInfo estructura con métricas de procesos.
+ *
+ * @throws std::runtime_error si no se pueden abrir o parsear
+ *         los archivos requeridos.
+ */
+ProcInfo getProcInfo();
+
+} // namespace pulso::collectors


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `CollectorProcesos` para obtener métricas de procesos del sistema desde `/proc/stat` y `/proc/loadavg`.

## Cambios realizados

* Se agregó `src/collectors/procesos/proc_collector.h`
* Se agregó `src/collectors/procesos/proc_collector.cpp`
* Se implementó `getProcInfo()` retornando:

  * `running`
  * `blocked`
  * `total`
* Se agregó lectura de:

  * `procs_running`
  * `procs_blocked`
    desde `/proc/stat`
* Se agregó parsing del campo `activos/total` desde `/proc/loadavg`
* Se implementó manejo de errores con `std::runtime_error`
* Se garantiza que `running <= total`

## Issue relacionado
Closes #267 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde