### PR TITLE
feat(formatters): implementar FormatterText — salida de texto plano legible para humanos

### DIFF
--- a/src/formatters/formatter_text.cpp
+++ b/src/formatters/formatter_text.cpp
@@ -1,0 +1,70 @@
+#include "formatter_text.hpp"
+
+#include <sstream>
+#include <iomanip>
+#include <cmath>
+
+namespace pulso::formatters {
+
+std::string FormatterText::formato() const {
+    return "text";
+}
+
+std::string FormatterText::contentType() const {
+    return "text/plain";
+}
+
+std::string FormatterText::formatear(
+    const pulso::core::Snapshot& snapshot
+) const {
+    // Extraer métricas del snapshot
+    double cpu_pct = 0.0;
+    double ram_usado_gb = 0.0;
+    double ram_total_gb = 0.0;
+    double disco_usado_gb = 0.0;
+    double disco_total_gb = 0.0;
+    double net_rx_kbs = 0.0;
+    double net_tx_kbs = 0.0;
+
+    for (const auto& metrica : snapshot.metrics) {
+        if (metrica.name == "cpu" || metrica.name == "cpu_usage") {
+            cpu_pct = metrica.value;
+        } else if (metrica.name == "ram_used" || metrica.name == "memory_used") {
+            ram_usado_gb = metrica.value;
+        } else if (metrica.name == "ram_total" || metrica.name == "memory_total") {
+            ram_total_gb = metrica.value;
+        } else if (metrica.name == "disk_used") {
+            disco_usado_gb = metrica.value;
+        } else if (metrica.name == "disk_total") {
+            disco_total_gb = metrica.value;
+        } else if (metrica.name == "network_rx" || metrica.name == "net_rx") {
+            net_rx_kbs = metrica.value;
+        } else if (metrica.name == "network_tx" || metrica.name == "net_tx") {
+            net_tx_kbs = metrica.value;
+        }
+    }
+
+    // Formatear línea: timestamp | CPU: 45.3% | RAM: 2.1/8.0 GB | Disco: 120/500 GB | Red: 1.2/0.8 KB/s
+    std::ostringstream oss;
+    oss << snapshot.timestamp
+        << " | CPU: " << std::fixed << std::setprecision(1) << cpu_pct << "%"
+        << " | RAM: " << ram_usado_gb << "/" << ram_total_gb << " GB"
+        << " | Disco: " << disco_usado_gb << "/" << disco_total_gb << " GB"
+        << " | Red: " << net_rx_kbs << "/" << net_tx_kbs << " KB/s";
+
+    return oss.str();
+}
+
+std::string FormatterText::formatearHistorial(
+    const std::vector<pulso::core::Snapshot>& snapshots
+) const {
+    std::ostringstream oss;
+
+    for (const auto& snapshot : snapshots) {
+        oss << formatear(snapshot) << "\n";
+    }
+
+    return oss.str();
+}
+
+} // namespace pulso::formatters

--- a/src/formatters/formatter_text.cpp
+++ b/src/formatters/formatter_text.cpp
@@ -2,7 +2,7 @@
 
 #include <sstream>
 #include <iomanip>
-#include <cmath>
+#include <ctime>
 
 namespace pulso::formatters {
 
@@ -12,6 +12,26 @@ std::string FormatterText::formato() const {
 
 std::string FormatterText::contentType() const {
     return "text/plain";
+}
+
+// Convierte timestamp Unix (segundos) a string ISO 8601
+static std::string formatearTimestamp(std::int64_t ts) {
+    std::time_t tiempo = static_cast<std::time_t>(ts);
+    std::tm* tm = std::gmtime(&tiempo);
+    
+    std::ostringstream oss;
+    oss << std::put_time(tm, "%Y-%m-%dT%H:%M:%SZ");
+    return oss.str();
+}
+
+// Convierte bytes a GB con 1 decimal
+static double bytesAGB(double bytes) {
+    return bytes / (1024.0 * 1024.0 * 1024.0);
+}
+
+// Convierte bytes a KB/s con 1 decimal
+static double bytesAKBs(double bytes) {
+    return bytes / 1024.0;
 }
 
 std::string FormatterText::formatear(
@@ -26,27 +46,27 @@ std::string FormatterText::formatear(
     double net_rx_kbs = 0.0;
     double net_tx_kbs = 0.0;
 
-    for (const auto& metrica : snapshot.metrics) {
-        if (metrica.name == "cpu" || metrica.name == "cpu_usage") {
-            cpu_pct = metrica.value;
-        } else if (metrica.name == "ram_used" || metrica.name == "memory_used") {
-            ram_usado_gb = metrica.value;
-        } else if (metrica.name == "ram_total" || metrica.name == "memory_total") {
-            ram_total_gb = metrica.value;
-        } else if (metrica.name == "disk_used") {
-            disco_usado_gb = metrica.value;
-        } else if (metrica.name == "disk_total") {
-            disco_total_gb = metrica.value;
-        } else if (metrica.name == "network_rx" || metrica.name == "net_rx") {
-            net_rx_kbs = metrica.value;
-        } else if (metrica.name == "network_tx" || metrica.name == "net_tx") {
-            net_tx_kbs = metrica.value;
+    for (const auto& metrica : snapshot.metricas) {
+        if (metrica.nombre == "cpu.usage" || metrica.nombre == "cpu") {
+            cpu_pct = metrica.valor;
+        } else if (metrica.nombre == "ram.used" || metrica.nombre == "ram.usado") {
+            ram_usado_gb = bytesAGB(metrica.valor);
+        } else if (metrica.nombre == "ram.total" || metrica.nombre == "ram.total") {
+            ram_total_gb = bytesAGB(metrica.valor);
+        } else if (metrica.nombre == "disk.used" || metrica.nombre == "disco.usado") {
+            disco_usado_gb = bytesAGB(metrica.valor);
+        } else if (metrica.nombre == "disk.total" || metrica.nombre == "disco.total") {
+            disco_total_gb = bytesAGB(metrica.valor);
+        } else if (metrica.nombre == "network.rx" || metrica.nombre == "net.rx") {
+            net_rx_kbs = bytesAKBs(metrica.valor);
+        } else if (metrica.nombre == "network.tx" || metrica.nombre == "net.tx") {
+            net_tx_kbs = bytesAKBs(metrica.valor);
         }
     }
 
     // Formatear línea: timestamp | CPU: 45.3% | RAM: 2.1/8.0 GB | Disco: 120/500 GB | Red: 1.2/0.8 KB/s
     std::ostringstream oss;
-    oss << snapshot.timestamp
+    oss << formatearTimestamp(snapshot.timestamp)
         << " | CPU: " << std::fixed << std::setprecision(1) << cpu_pct << "%"
         << " | RAM: " << ram_usado_gb << "/" << ram_total_gb << " GB"
         << " | Disco: " << disco_usado_gb << "/" << disco_total_gb << " GB"

--- a/src/formatters/formatter_text.hpp
+++ b/src/formatters/formatter_text.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "iformatter.hpp"
+#include "core/types.hpp"
+
+namespace pulso::formatters {
+
+/**
+ * @brief Formateador de texto plano legible para humanos.
+ *
+ * Genera una línea de texto con las métricas principales del sistema:
+ * timestamp | CPU% | RAM usada/total GB | Disco usado/total GB | Red rx/tx KB/s
+ */
+class FormatterText : public IFormatter {
+public:
+    /**
+     * @brief Retorna el identificador del formato.
+     */
+    std::string formato() const override;
+
+    /**
+     * @brief Retorna el content type HTTP.
+     */
+    std::string contentType() const override;
+
+    /**
+     * @brief Serializa un snapshot individual en texto plano.
+     */
+    std::string formatear(
+        const pulso::core::Snapshot& snapshot
+    ) const override;
+
+    /**
+     * @brief Serializa un historial de snapshots en texto plano.
+     */
+    std::string formatearHistorial(
+        const std::vector<pulso::core::Snapshot>& snapshots
+    ) const override;
+};
+
+} // namespace pulso::formatters


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa un formatter de texto plano legible para humanos, útil para debug y logs de sistema.

## Cambios
- Crea `src/formatters/formatter_text.hpp`.
- Crea `src/formatters/formatter_text.cpp`.
- Implementa `IFormatter` con:
  - `formato()` → `"text"`.
  - `contentType()` → `"text/plain"`.
  - `formatear()` → línea con timestamp ISO, CPU%, RAM GB, Disco GB, Red KB/s.
  - `formatearHistorial()` → múltiples líneas.

## Formato de salida
2024-01-15T10:30:00Z | CPU: 45.3% | RAM: 2.1/8.0 GB | Disco: 120.0/500.0 GB | Red: 1.2/0.8 KB/s

## Issue relacionado
Closes #295

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas