### PR TITLE
chore: configurar ctest en el CI para ejecutar tests C++ automáticamente en cada PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: CI
-
 on:
   pull_request:
     branches: [dev, main]
-
 jobs:
   validar-pr:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
       - name: Verificar descripción del PR
         run: |
           if [ -z "${{ github.event.pull_request.body }}" ]; then
@@ -15,7 +15,6 @@ jobs:
             exit 1
           fi
           echo "✅ PR tiene descripción"
-
       - name: Verificar que referencia un issue
         run: |
           if ! echo "${{ github.event.pull_request.body }}" | grep -qi "closes #\|fixes #\|refs #"; then
@@ -23,3 +22,18 @@ jobs:
             exit 1
           fi
           echo "✅ PR referencia un issue"
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout código
+        uses: actions/checkout@v4
+      - name: Instalar dependencias
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake g++ libgtest-dev libsqlite3-dev
+      - name: Configurar CMake con tests
+        run: cmake -S . -B build -DBUILD_TESTS=ON
+      - name: Compilar
+        run: cmake --build build
+      - name: Ejecutar tests con ctest
+        run: cd build && ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,15 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-option(PULSO_BUILD_TESTS "Build tests" ON)
+# Criterio de aceptación: Desactivado (OFF) por defecto para compilaciones limpias
+option(BUILD_TESTS "Build tests" OFF)
+option(PULSO_BUILD_TESTS "Build tests (Legacy)" OFF)
+
+# Si el usuario activa cualquiera de las dos opciones, sincronizamos el estado
+if(BUILD_TESTS OR PULSO_BUILD_TESTS)
+    set(BUILD_TESTS ON CACHE BOOL "Build tests" FORCE)
+    set(PULSO_BUILD_TESTS ON CACHE BOOL "Build tests (Legacy)" FORCE)
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
@@ -17,12 +25,11 @@ add_subdirectory(src)
 # Los siguientes subdirectorios están vacíos o pendientes de implementación.
 # Se comentan para evitar advertencias de CMake sobre directorios sin archivos fuente.
 # Descomentar cuando se agreguen archivos fuente en cada directorio.
-
 # add_subdirectory(src/collectors/disk)
 # add_subdirectory(src/collectors/network)
 # add_subdirectory(src/alertas)
 # add_subdirectory(src/config)
 
-if(PULSO_BUILD_TESTS)
+if(BUILD_TESTS)
     add_subdirectory(tests)
 endif()


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el job build-and-test en .github/workflows/ci.yml que ejecuta cmake, compila el proyecto y corre ctest --output-on-failure en cada PR hacia dev. Actualiza CMakeLists.txt agregando la opción BUILD_TESTS sincronizada con PULSO_BUILD_TESTS, ambas desactivadas por defecto para que la compilación sin tests siga funcionando.

## Issue relacionado
Closes #300 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="862" height="592" alt="image" src="https://github.com/user-attachments/assets/37a168a2-70fd-4f64-8ddd-131468526dab" />
