### PR TITLE
feat(collectors): implementar CollectorLoadAverage desde /proc/loadavg

### DIFF
--- a/src/collectors/loadavg/loadavg_collector.cpp
+++ b/src/collectors/loadavg/loadavg_collector.cpp
@@ -1,0 +1,22 @@
+#include "loadavg_collector.h"
+#include <fstream>
+#include <stdexcept>
+
+LoadAvgInfo getLoadAverage() {
+    // Abrir el archivo virtual del sistema operativo Linux
+    std::ifstream file("/proc/loadavg");
+    
+    // Criterio de aceptación: Lanzar std::runtime_error si no existe o no se puede abrir
+    if (!file.is_open()) {
+        throw std::runtime_error("Error: No se pudo abrir o no existe el archivo /proc/loadavg");
+    }
+    
+    LoadAvgInfo info{0.0f, 0.0f, 0.0f};
+    
+    // Leer y parsear los primeros 3 valores float separados por espacios en blanco
+    if (!(file >> info.load1 >> info.load5 >> info.load15)) {
+        throw std::runtime_error("Error: El formato de /proc/loadavg es invalido");
+    }
+    
+    return info;
+}

--- a/src/collectors/loadavg/loadavg_collector.h
+++ b/src/collectors/loadavg/loadavg_collector.h
@@ -1,0 +1,21 @@
+#ifndef LOADAVG_COLLECTOR_H
+#define LOADAVG_COLLECTOR_H
+
+/**
+ * Estructura que almacena los promedios de carga del sistema
+ * para los últimos 1, 5 y 15 minutos respectivamente.
+ */
+struct LoadAvgInfo {
+    float load1;
+    float load5;
+    float load15;
+};
+
+/**
+ * Lee el archivo virtual /proc/loadavg y extrae los promedios de carga.
+ * @return Una estructura LoadAvgInfo poblada con las métricas del sistema.
+ * @throws std::runtime_error si el archivo no puede abrirse o no existe.
+ */
+LoadAvgInfo getLoadAverage();
+
+#endif // LOADAVG_COLLECTOR_H


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa de manera autónoma el recolector `CollectorLoadAverage` dentro del directorio `src/collectors/loadavg/`. El módulo lee y parsea el archivo virtual del sistema Linux `/proc/loadavg` para extraer de forma precisa las métricas de carga de la CPU correspondientes a los últimos 1, 5 y 15 minutos en una estructura dedicada.

## Issue relacionado
Closes #292

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se realizaron pruebas de compilación y ejecución aisladas en un entorno local con Linux Mint, logrando leer con éxito las cargas del sistema operativo en tiempo real:

* Estado de la prueba: Intentando leer la carga del sistema...
* Carga 1 min: 1.72
* Carga 5 min: 1.79
* Carga 15 min: 1.78
* Validación: Criterio exitoso, todos los valores son mayores o iguales a 0.0

Validaciones técnicas verificadas de manera estricta:
* Ambos archivos existen, están correctamente estructurados y compilan de forma limpia con C++17.
* La función retorna la estructura correctamente poblada.
* Se introdujo una validación que comprueba si el flujo se abrió de manera correcta, lanzando la excepción std::runtime_error solicitada si el archivo no existe.
* El repositorio quedó completamente limpio; no se modificó ningún archivo existente fuera del listado asignado.