### PR TITLE
feat(platform): implement CollectorNetworkLinux reading /proc/net/dev - Closes #287

### DIFF
--- a/src/platform/linux/collector_network.cpp
+++ b/src/platform/linux/collector_network.cpp
@@ -1,0 +1,127 @@
+#include "collector_network.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <ctime>
+
+namespace pulso::platform::linux_platform {
+
+std::string CollectorNetworkLinux::nombre() const {
+    return "network";
+}
+
+std::vector<pulso::core::Metrica> CollectorNetworkLinux::recolectar() {
+    // /proc/net/dev tiene dos líneas de cabecera antes de los datos:
+    //
+    //   Inter-|   Receive                                                |  Transmit
+    //    face |bytes    packets errs drop fifo frame compressed multicast|bytes    ...
+    //       lo:   12345  ...
+    //     eth0: 4096000  ...
+    //
+    // Cada línea de datos tiene el formato:
+    //   <iface>: rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame
+    //            rx_compressed rx_multicast tx_bytes tx_packets ...
+    // Los índices de columna (0-based, tras el ":") son:
+    //   0  → rx_bytes
+    //   8  → tx_bytes
+
+    std::ifstream file("/proc/net/dev");
+    if (!file.is_open()) {
+        throw pulso::collectors::ErrorRecoleccion(
+            "No se pudo abrir /proc/net/dev"
+        );
+    }
+
+    // Saltar las dos líneas de cabecera
+    std::string linea;
+    for (int i = 0; i < 2; ++i) {
+        if (!std::getline(file, linea)) {
+            throw pulso::collectors::ErrorRecoleccion(
+                "Formato inesperado en /proc/net/dev: cabecera incompleta"
+            );
+        }
+    }
+
+    long long total_rx_bytes = 0;
+    long long total_tx_bytes = 0;
+    bool hay_interfaces = false;
+
+    while (std::getline(file, linea)) {
+        // Buscar el separador ":" que delimita el nombre de la interfaz
+        const std::string::size_type pos_colon = linea.find(':');
+        if (pos_colon == std::string::npos) {
+            continue; // línea malformada, ignorar
+        }
+
+        // Extraer y limpiar el nombre de la interfaz
+        std::string iface = linea.substr(0, pos_colon);
+        // Eliminar espacios en blanco al inicio y al final del nombre
+        const auto inicio = iface.find_first_not_of(" \t");
+        const auto fin    = iface.find_last_not_of(" \t");
+        if (inicio == std::string::npos) {
+            continue; // nombre vacío, ignorar
+        }
+        iface = iface.substr(inicio, fin - inicio + 1);
+
+        // Excluir la interfaz loopback: no representa tráfico real de red
+        if (iface == "lo") {
+            continue;
+        }
+
+        // Parsear los valores numéricos tras el ":"
+        // Orden: rx_bytes rx_packets rx_errs rx_drop rx_fifo rx_frame
+        //        rx_compressed rx_multicast tx_bytes tx_packets ...
+        std::istringstream iss(linea.substr(pos_colon + 1));
+        long long rx_bytes = 0;
+        long long campo    = 0;
+
+        // Columna 0: rx_bytes
+        if (!(iss >> rx_bytes)) {
+            throw pulso::collectors::ErrorRecoleccion(
+                "Formato inesperado en /proc/net/dev: no se pudo leer rx_bytes"
+                " para la interfaz " + iface
+            );
+        }
+
+        // Columnas 1-7: rx_packets, rx_errs, rx_drop, rx_fifo,
+        //               rx_frame, rx_compressed, rx_multicast
+        for (int i = 0; i < 7; ++i) {
+            if (!(iss >> campo)) {
+                throw pulso::collectors::ErrorRecoleccion(
+                    "Formato inesperado en /proc/net/dev: campos RX incompletos"
+                    " para la interfaz " + iface
+                );
+            }
+        }
+
+        // Columna 8: tx_bytes
+        long long tx_bytes = 0;
+        if (!(iss >> tx_bytes)) {
+            throw pulso::collectors::ErrorRecoleccion(
+                "Formato inesperado en /proc/net/dev: no se pudo leer tx_bytes"
+                " para la interfaz " + iface
+            );
+        }
+
+        total_rx_bytes += rx_bytes;
+        total_tx_bytes += tx_bytes;
+        hay_interfaces  = true;
+    }
+
+    if (!hay_interfaces) {
+        throw pulso::collectors::ErrorRecoleccion(
+            "No se encontraron interfaces de red activas en /proc/net/dev"
+        );
+    }
+
+    // Timestamp actual en segundos Unix
+    const std::int64_t ahora = static_cast<std::int64_t>(std::time(nullptr));
+
+    return {
+        {"network.rx_bytes", static_cast<double>(total_rx_bytes), "bytes", ahora},
+        {"network.tx_bytes", static_cast<double>(total_tx_bytes), "bytes", ahora},
+    };
+}
+
+} // namespace pulso::platform::linux_platform

--- a/src/platform/linux/collector_network.hpp
+++ b/src/platform/linux/collector_network.hpp
@@ -1,0 +1,42 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "../../collectors/icollector.hpp"
+#include "../../collectors/error_recoleccion.hpp"
+#include "../../core/types.hpp"
+
+namespace pulso::platform::linux_platform {
+
+/**
+ * @brief Collector que mide el tráfico de red acumulado desde /proc/net/dev.
+ *
+ * Lee el pseudo-archivo /proc/net/dev del kernel de Linux, que expone
+ * estadísticas de red por interfaz. Suma rx_bytes y tx_bytes de todas
+ * las interfaces activas, excluyendo el loopback ("lo") que no representa
+ * tráfico real de red.
+ *
+ * Formato relevante de /proc/net/dev (columnas por interfaz):
+ *   face | rx_bytes rx_packets ... | tx_bytes tx_packets ...
+ *
+ * Las métricas devueltas son:
+ *   - network.rx_bytes : total de bytes recibidos (todas las ifaces salvo lo)
+ *   - network.tx_bytes : total de bytes transmitidos (todas las ifaces salvo lo)
+ *
+ * @note Los valores son contadores acumulados desde el arranque del sistema,
+ *       no tasas. El consumidor es responsable de calcular deltas si necesita
+ *       ancho de banda en tiempo real.
+ */
+class CollectorNetworkLinux : public pulso::collectors::ICollector {
+public:
+    /// @brief Retorna el nombre identificador de este collector.
+    /// @return "network"
+    std::string nombre() const override;
+
+    /// @brief Recolecta las métricas de red del sistema.
+    /// @return Vector con network.rx_bytes y network.tx_bytes en bytes.
+    /// @throws pulso::collectors::ErrorRecoleccion si /proc/net/dev no puede abrirse
+    ///         o si el formato del archivo es inesperado.
+    std::vector<pulso::core::Metrica> recolectar() override;
+};
+
+} // namespace pulso::platform::linux_platform


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `CollectorNetworkLinux` en los archivos `src/platform/linux/collector_network.hpp` y `src/platform/linux/collector_network.cpp`, siguiendo el mismo patrón de `CollectorDisk`.

Lee `/proc/net/dev`, excluye la interfaz `lo` y suma `rx_bytes` y `tx_bytes` de todas las interfaces activas, devolviendo las métricas `network.rx_bytes` y `network.tx_bytes` en bytes.

## Cambios introducidos

- `src/platform/linux/collector_network.hpp` — declara `CollectorNetworkLinux` heredando de `ICollector`.
- `src/platform/linux/collector_network.cpp` — implementa `nombre()` y `recolectar()`: abre `/proc/net/dev`, salta las dos líneas de cabecera, parsea columna 0 (rx_bytes) y columna 8 (tx_bytes) por interfaz, excluye `lo`, y retorna el total acumulado con timestamp Unix.

## Issue relacionado
Closes #287 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde