### PR TITLE
feat(collectors): implementar CollectorTemperatura — temperatura de CPU desde /sys/class/thermal  - Closes#268

### DIFF
--- a/src/collectors/temperatura/temp_collector.cpp
+++ b/src/collectors/temperatura/temp_collector.cpp
@@ -1,0 +1,47 @@
+#include "temp_collector.h"
+
+#include <fstream>
+#include <string>
+
+namespace collectors {
+
+namespace {
+
+constexpr const char* kThermalZonePath =
+    "/sys/class/thermal/thermal_zone0/temp";
+
+constexpr const char* kZoneName = "thermal_zone0";
+
+constexpr float kMilliCelsiusDivisor = 1000.0f;
+
+} // namespace
+
+TempInfo getTempInfo()
+{
+    std::ifstream file(kThermalZonePath);
+
+    if (!file.is_open()) {
+        return TempInfo{
+            /* cpu_celsius */ 0.0f,
+            /* zona        */ kZoneName,
+            /* disponible  */ false
+        };
+    }
+
+    long raw_millicelsius = 0;
+    if (!(file >> raw_millicelsius)) {
+        return TempInfo{
+            /* cpu_celsius */ 0.0f,
+            /* zona        */ kZoneName,
+            /* disponible  */ false
+        };
+    }
+
+    return TempInfo{
+        /* cpu_celsius */ static_cast<float>(raw_millicelsius) / kMilliCelsiusDivisor,
+        /* zona        */ kZoneName,
+        /* disponible  */ true
+    };
+}
+
+} // namespace collectors

--- a/src/collectors/temperatura/temp_collector.h
+++ b/src/collectors/temperatura/temp_collector.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string>
+
+namespace collectors {
+
+struct TempInfo {
+    float       cpu_celsius;
+    std::string zona;
+    bool        disponible;
+};
+
+/**
+ * Lee la temperatura de CPU desde /sys/class/thermal/thermal_zone0/temp.
+ *
+ * El kernel expone el valor como entero en milicélsius; esta función lo
+ * divide entre 1000.0f para retornarlo en grados Celsius.
+ *
+ * Si el archivo no existe o no puede leerse, retorna TempInfo con
+ * disponible=false y cpu_celsius=0.0f — nunca lanza excepción.
+ */
+TempInfo getTempInfo();
+
+} // namespace collectors


### PR DESCRIPTION
## ¿Qué hace este PR?
Los archivos `src/collectors/temperatura/temp_collector.hpp` y `src/collectors/temperatura/temp_collector.cpp` son nuevos y fueron creados en este PR según lo especificado en el issue.
 
## Archivos
- `src/collectors/temperatura/temp_collector.h`
- `src/collectors/temperatura/temp_collector.cpp`
## Qué hace
 
`getTempInfo()` lee la temperatura de CPU desde `/sys/class/thermal/thermal_zone0/temp` y retorna un `TempInfo` con el valor convertido a Celsius:
- Si el archivo existe y es legible: retorna `disponible=true` con `cpu_celsius` calculado dividiendo el valor raw entre `1000.0f`
- Si el archivo no existe o no puede leerse: retorna `disponible=false` y `cpu_celsius=0.0f` sin lanzar excepción, para ser compatible con máquinas virtuales o arquitecturas que no exponen zona térmica
## Nota sobre CMakeLists.txt
 
El issue no lista `CMakeLists.txt` como archivo a tocar. Sin embargo, `temperatura/temp_collector.cpp` no está registrado en `target_sources`, por lo que el compilador no lo incluye en el build y el criterio *"ambos archivos compilan"* no se puede verificar en el contexto del proyecto.
 
Se debería agregar la siguiente línea en `target_sources` como cambio mínimo e inevitable para satisfacer ese criterio:
 
```cmake
target_sources(collectors PRIVATE
    temperatura/temp_collector.cpp
)
```

## Issue relacionado
Closes #268 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde