### PR TITLE
feat(platform): implement CollectorMemoryLinux reading RAM from /proc/meminfo - Closes #285

### DIFF
--- a/src/platform/linux/collector_memory.cpp
+++ b/src/platform/linux/collector_memory.cpp
@@ -1,76 +1,76 @@
 #include "collector_memory.hpp"
-#include "../../collectors/error_recoleccion.hpp"
 
 #include <fstream>
-#include <sstream>
 #include <string>
+#include <ctime>
 
-namespace pulso::collectors {
+namespace pulso::platform::linux_platform {
 
-std::string CollectorMemory::nombre() const {
+std::string CollectorMemoryLinux::nombre() const {
     return "memory";
 }
 
-std::vector<pulso::core::Metrica> CollectorMemory::recolectar() {
-    std::ifstream file("/proc/meminfo");
+std::vector<pulso::core::Metrica> CollectorMemoryLinux::recolectar() {
+    // /proc/meminfo tiene el formato:
+    //   FieldName:   <valor> kB
+    // Se leen línea por línea buscando MemTotal y MemAvailable.
+    // Ambos campos están presentes en cualquier kernel Linux >= 3.14.
 
+    std::ifstream file("/proc/meminfo");
     if (!file.is_open()) {
-        throw ErrorRecoleccion("No se pudo abrir /proc/meminfo");
+        throw pulso::collectors::ErrorRecoleccion(
+            "No se pudo abrir /proc/meminfo"
+        );
     }
 
-    long long memTotalKB = -1;
+    long long memTotalKB     = -1;
     long long memAvailableKB = -1;
-    long long memFreeKB = -1;
 
     std::string key;
-    long long value;
+    long long   value;
     std::string unit;
 
+    // Parseo directo: cada línea tiene la forma "Clave:   valor kB"
     while (file >> key >> value >> unit) {
         if (key == "MemTotal:") {
             memTotalKB = value;
         } else if (key == "MemAvailable:") {
             memAvailableKB = value;
-        } else if (key == "MemFree:") {
-            memFreeKB = value;
+        }
+
+        // Salida temprana: ya tenemos los dos campos que necesitamos
+        if (memTotalKB >= 0 && memAvailableKB >= 0) {
+            break;
         }
     }
 
-    if (memTotalKB < 0 || memAvailableKB < 0 || memFreeKB < 0) {
-        throw ErrorRecoleccion(
-            "No se encontraron las claves requeridas en /proc/meminfo"
+    if (memTotalKB < 0) {
+        throw pulso::collectors::ErrorRecoleccion(
+            "No se encontró el campo MemTotal en /proc/meminfo"
+        );
+    }
+    if (memAvailableKB < 0) {
+        throw pulso::collectors::ErrorRecoleccion(
+            "No se encontró el campo MemAvailable en /proc/meminfo"
         );
     }
 
-    const double memTotalBytes =
-        static_cast<double>(memTotalKB) * 1024.0;
+    // Convertir de kB a bytes
+    const double totalBytes     = static_cast<double>(memTotalKB)     * 1024.0;
+    const double availableBytes = static_cast<double>(memAvailableKB) * 1024.0;
 
-    const double memAvailableBytes =
-        static_cast<double>(memAvailableKB) * 1024.0;
+    // used = MemTotal - MemAvailable
+    // Invariante garantizada por el kernel: MemAvailable <= MemTotal,
+    // por lo tanto used_bytes >= 0 y used_bytes <= total_bytes siempre.
+    const double usedBytes = totalBytes - availableBytes;
 
-    const double memUsedBytes =
-        static_cast<double>(memTotalKB - memAvailableKB) * 1024.0;
+    const std::int64_t ahora = static_cast<std::int64_t>(std::time(nullptr));
 
     return {
-        pulso::core::Metrica{
-            "memory.total",
-            memTotalBytes,
-            "bytes",
-            0
-        },
-        pulso::core::Metrica{
-            "memory.used",
-            memUsedBytes,
-            "bytes",
-            0
-        },
-        pulso::core::Metrica{
-            "memory.available",
-            memAvailableBytes,
-            "bytes",
-            0
-        }
+        {"memory.total_bytes",     totalBytes,     "bytes", ahora},
+        {"memory.used_bytes",      usedBytes,      "bytes", ahora},
+        {"memory.available_bytes", availableBytes, "bytes", ahora},
     };
 }
 
-} // namespace pulso::collectors
+} // namespace pulso::platform::linux_platform

--- a/src/platform/linux/collector_memory.hpp
+++ b/src/platform/linux/collector_memory.hpp
@@ -1,15 +1,44 @@
 #pragma once
-
-#include "../../collectors/icollector.hpp"
-#include <vector>
 #include <string>
+#include <vector>
+#include "../../collectors/icollector.hpp"
+#include "../../collectors/error_recoleccion.hpp"
+#include "../../core/types.hpp"
 
-namespace pulso::collectors {
+namespace pulso::platform::linux_platform {
 
-class CollectorMemory : public ICollector {
+/**
+ * @brief Collector que mide el uso de memoria RAM desde /proc/meminfo.
+ *
+ * Lee los campos MemTotal y MemAvailable del pseudo-archivo /proc/meminfo
+ * del kernel de Linux. El espacio usado se calcula como:
+ *
+ *   memory.used_bytes = MemTotal - MemAvailable
+ *
+ * Esta fórmula es la misma que usa `free(1)` en su columna "used" y refleja
+ * la memoria realmente consumida por procesos y caché no recuperable, a
+ * diferencia de MemTotal - MemFree, que excluye caché y buffers reutilizables.
+ *
+ * Las métricas devueltas son:
+ *   - memory.total_bytes    : total de RAM física (MemTotal × 1024)
+ *   - memory.used_bytes     : RAM en uso efectivo (MemTotal - MemAvailable) × 1024
+ *   - memory.available_bytes: RAM disponible para nuevas asignaciones (MemAvailable × 1024)
+ *
+ * La invariante memory.used_bytes <= memory.total_bytes se mantiene siempre
+ * porque MemAvailable <= MemTotal en cualquier sistema Linux.
+ */
+class CollectorMemoryLinux : public pulso::collectors::ICollector {
 public:
+    /// @brief Retorna el nombre identificador de este collector.
+    /// @return "memory"
     std::string nombre() const override;
+
+    /// @brief Recolecta las métricas de uso de memoria RAM del sistema.
+    /// @return Vector con memory.total_bytes, memory.used_bytes y
+    ///         memory.available_bytes, todos en bytes.
+    /// @throws pulso::collectors::ErrorRecoleccion si /proc/meminfo no puede
+    ///         abrirse o si los campos requeridos no están presentes.
     std::vector<pulso::core::Metrica> recolectar() override;
 };
 
-} // namespace pulso::collectors
+} // namespace pulso::platform::linux_platform


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa `CollectorMemoryLinux` en los archivos `src/platform/linux/collector_memory.hpp` y `src/platform/linux/collector_memory.cpp`, siguiendo el mismo patrón de namespace y manejo de errores que `CollectorDisk` y `CollectorNetworkLinux` en la misma carpeta.

Lee los campos `MemTotal` y `MemAvailable` de `/proc/meminfo` y calcula la memoria usada como `MemTotal - MemAvailable`, la misma fórmula que usa `free(1)`. Retorna las métricas `memory.total_bytes`, `memory.used_bytes` y `memory.available_bytes` en bytes.

## Cambios introducidos

- `src/platform/linux/collector_memory.hpp` — declara `CollectorMemoryLinux` heredando de `ICollector`, explicando la fórmula de cálculo y la invariante `used ≤ total`.
- `src/platform/linux/collector_memory.cpp` — implementa `nombre()` y `recolectar()`: abre `/proc/meminfo`, parsea `MemTotal` y `MemAvailable` con salida temprana al encontrar ambos campos, convierte de kB a bytes y retorna las tres métricas con timestamp Unix.

## Notas

Se usa `MemAvailable` en lugar de `MemFree` para calcular la memoria disponible porque `MemAvailable` incluye caché y buffers que el kernel puede liberar bajo demanda, siendo el valor que realmente refleja cuánta RAM puede usar un nuevo proceso. Esta es la misma lógica que usa `free(1)` en su columna "available".

## Issue relacionado
Closes #285 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde