### PR TITLE
chore:configurar clang-tidy en CI para analisis estatico

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,19 @@
+---
+Checks: '
+bugprone-*,
+cppcoreguidelines-*,
+modernize-*,
+performance-*,
+readability-*,
+-*readability-magic-numbers,
+-*cppcoreguidelines-avoid-magic-numbers,
+-*readability-identifier-length,
+'
+
+CheckOptions:
+  - key: readability-identifier-length.MinVariableNameLength
+    value: '2'
+  - key: readability-identifier-length.MinParameterNameLength
+    value: '2'
+  - key: modernize-use-auto.MinTypeNameLength
+    value: '5'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,17 @@ jobs:
         run: cmake -S . -B build -DBUILD_TESTS=ON
       - name: Compilar
         run: cmake --build build
+      - name: Install clang-tidy
+        run: |
+          sudo apt update
+          sudo apt install -y clang-tidy-14
+          sudo ln -s /usr/bin/clang-tidy-14 /usr/bin/clang-tidy
+      - name: Run clang-tidy
+        run: |
+          find src/ -name "*.cpp" -o -name "*.cxx" -o -name "*.cc" | \
+          xargs clang-tidy --config-file=.clang-tidy -- -std=c++17 || true
+      - name: Run clang-tidy on main.cpp specifically
+        run: |
+          clang-tidy src/main.cpp --config-file=.clang-tidy -- -std=c++17 || true
       - name: Ejecutar tests con ctest
         run: cd build && ctest --output-on-failure


### PR DESCRIPTION
## ¿Qué hace este PR?

Configura clang-tidy en el CI para análisis estático del código C++:

1. Crea `.clang-tidy` con 5 categorías de checks:
   - bugprone-*
   - cppcoreguidelines-*
   - modernize-*
   - performance-*
   - readability-*

2. Agrega step en `.github/workflows/ci.yml` que:
   - Instala clang-tidy
   - Ejecuta análisis sobre todos los archivos `src/**/*.cpp`
   - No falla el CI por advertencias existentes (`|| true`)

## Issue relacionado
Closes #299

## Tipo de cambio
- [x] chore — configuración

## Checklist
- [x] `.clang-tidy` existe con al menos 3 categorías de checks activas
- [x] El step de clang-tidy se ejecuta en cada PR
- [x] No se modificaron archivos de código fuente
## Evidencia / capturas
<img width="778" height="321" alt="Screenshot_2026-06-04_00-03-18" src="https://github.com/user-attachments/assets/62be421e-0a00-439e-8579-f35bcd2c385b" />