### PR TITLE
docs(network): improve CollectorNetworkLinux documentation

### DIFF
--- a/src/platform/linux/collector_network.cpp
+++ b/src/platform/linux/collector_network.cpp
@@ -11,6 +11,13 @@ std::string CollectorNetworkLinux::nombre() const {
     return "network";
 }
 
+/**
+ * Lee /proc/net/dev y suma los contadores de todas las interfaces
+ * excepto la interfaz loopback ("lo").
+ *
+ * Retorna métricas acumuladas de recepción y transmisión expresadas
+ * en bytes.
+ */
 std::vector<pulso::core::Metrica> CollectorNetworkLinux::recolectar() {
     // /proc/net/dev tiene dos líneas de cabecera antes de los datos:
     //

--- a/src/platform/linux/collector_network.hpp
+++ b/src/platform/linux/collector_network.hpp
@@ -8,23 +8,27 @@
 namespace pulso::platform::linux_platform {
 
 /**
- * @brief Collector que mide el tráfico de red acumulado desde /proc/net/dev.
+ * @brief Implementación Linux del collector de métricas de red.
  *
- * Lee el pseudo-archivo /proc/net/dev del kernel de Linux, que expone
- * estadísticas de red por interfaz. Suma rx_bytes y tx_bytes de todas
- * las interfaces activas, excluyendo el loopback ("lo") que no representa
- * tráfico real de red.
+ * Este collector cumple el contrato definido para CollectorNetwork
+ * leyendo estadísticas desde /proc/net/dev.
  *
- * Formato relevante de /proc/net/dev (columnas por interfaz):
- *   face | rx_bytes rx_packets ... | tx_bytes tx_packets ...
+ * Para cada interfaz distinta de "lo" (loopback), acumula:
+ * - bytes recibidos (rx_bytes)
+ * - bytes transmitidos (tx_bytes)
  *
- * Las métricas devueltas son:
- *   - network.rx_bytes : total de bytes recibidos (todas las ifaces salvo lo)
- *   - network.tx_bytes : total de bytes transmitidos (todas las ifaces salvo lo)
+ * Las métricas devueltas representan contadores acumulados desde
+ * el arranque del sistema.
  *
- * @note Los valores son contadores acumulados desde el arranque del sistema,
- *       no tasas. El consumidor es responsable de calcular deltas si necesita
- *       ancho de banda en tiempo real.
+ * Métricas:
+ * - network.rx_bytes
+ * - network.tx_bytes
+ *
+ * Unidad:
+ * - bytes
+ *
+ * @throws ErrorRecoleccion si /proc/net/dev no puede leerse
+ *         o tiene un formato inválido.
  */
 class CollectorNetworkLinux : public pulso::collectors::ICollector {
 public:


### PR DESCRIPTION
## ¿Qué hace este PR?

Se revisó la implementación actual de `CollectorNetworkLinux` para verificar el cumplimiento de los requisitos definidos en el issue #95.

Durante la revisión se comprobó que la implementación existente:

* Hereda correctamente de `ICollector`.
* Retorna `"network"` desde el método `nombre()`.
* Lee las estadísticas desde `/proc/net/dev`.
* Excluye la interfaz de loopback (`lo`) del cálculo.
* Acumula correctamente los contadores `rx_bytes` y `tx_bytes`.
* Devuelve las métricas `network.rx_bytes` y `network.tx_bytes` en bytes.
* Lanza `ErrorRecoleccion` cuando el archivo no es accesible o presenta un formato inesperado.

## Issue relacionado
Closes #95

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

### Verificación realizada

Se validó que la implementación actual cumple los criterios de aceptación del issue:

* `CollectorNetworkLinux` implementa la interfaz `ICollector`.
* `nombre()` retorna `"network"`.
* `recolectar()` genera las métricas:

  * `network.rx_bytes`
  * `network.tx_bytes`
* La interfaz `lo` es excluida de los totales.
* Se utiliza `/proc/net/dev` como fuente de datos.
* Se lanza `ErrorRecoleccion` ante errores de acceso o lectura.

También se verificó mediante el historial del repositorio que la funcionalidad ya se encontraba implementada previamente, por lo que este PR se enfoca en documentar y validar formalmente el comportamiento existente.