### PR TITLE
chore: add build matrix for Ubuntu 22.04 and 24.04 with -Wall -Wextra - Closes #329

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,12 @@ jobs:
           fi
           echo "✅ PR referencia un issue"
   build-and-test:
-    runs-on: ubuntu-latest
+    needs: validar-pr
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Checkout código
         uses: actions/checkout@v4
@@ -32,7 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y cmake g++ libgtest-dev libsqlite3-dev
       - name: Configurar CMake con tests
-        run: cmake -S . -B build -DBUILD_TESTS=ON
+        run: cmake -S . -B build -DBUILD_TESTS=ON -DCMAKE_CXX_FLAGS="-Wall -Wextra"
       - name: Compilar
         run: cmake --build build
       - name: Ejecutar tests con ctest


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega una `strategy.matrix` al job `build-and-test` de `.github/workflows/ci.yml` para compilar y testear en Ubuntu 22.04 y Ubuntu 24.04 en paralelo. También incorpora los flags `-Wall -Wextra` en el paso de configuración de CMake y agrega `needs: validar-pr` para evitar desperdiciar minutos de runner cuando el PR no cumple las validaciones de descripción.

## Cambios en `.github/workflows/ci.yml`

- `build-and-test` ahora usa `runs-on: ${{ matrix.os }}` con `matrix.os: [ubuntu-22.04, ubuntu-24.04]`
- `fail-fast: false` para que ambos runners completen aunque uno falle, obteniendo más información de diagnóstico
- Flags `-Wall -Wextra` agregados vía `-DCMAKE_CXX_FLAGS` en el paso de `cmake -S . -B build`
- `needs: validar-pr` en `build-and-test` para no lanzar runners si la validación de PR falla
- `validar-pr` permanece con `ubuntu-latest` fijo (no requiere matrix, no compila código)

## Issue relacionado
Closes #329 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde