### PR TITLE
chore: add pre-commit hooks for clang-format and code quality checks - Closes #326

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+repos:
+  # ── Hooks estándar de pre-commit ──────────────────────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      # Elimina espacios en blanco al final de cada línea
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+
+      # Garantiza que cada archivo termine con exactamente un salto de línea
+      - id: end-of-file-fixer
+
+      # Valida la sintaxis de todos los archivos YAML del repositorio
+      - id: check-yaml
+
+      # Impide hacer commit directamente en la rama main
+      - id: no-commit-to-branch
+        args: [--branch, main]
+
+  # ── Formateo de C++ con clang-format ─────────────────────────────────────
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        language: system
+        # Aplica el formato definido en .clang-format (BasedOnStyle: LLVM,
+        # IndentWidth: 2) directamente sobre los archivos modificados.
+        # -i edita en sitio; el estilo se toma automáticamente del
+        # .clang-format en la raíz del repositorio.
+        entry: clang-format -i
+        types_or: [c++, c]
+        files: \.(cpp|hpp|cc|cxx|h)$

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,61 @@ el **Forking Workflow**. Lee este documento antes de empezar.
 
 ---
 
+## Configuración del entorno de desarrollo
+
+Antes de empezar a trabajar en el código, instala los hooks de pre-commit.
+Esto garantiza que tu código esté correctamente formateado antes de cada commit.
+
+### Requisitos
+
+- Python 3.x
+- `clang-format` instalado y disponible en el PATH
+
+```bash
+# En Ubuntu / Debian
+sudo apt-get install clang-format
+
+# En macOS
+brew install clang-format
+```
+
+### Instalar pre-commit
+
+```bash
+# Instalar la herramienta
+pip install pre-commit
+
+# Registrar los hooks en tu copia local del repositorio
+# Ejecutar UNA SOLA VEZ después de clonar
+pre-commit install
+```
+
+A partir de ese momento, cada `git commit` ejecutará automáticamente:
+
+| Hook | Qué hace |
+|---|---|
+| `trailing-whitespace` | Elimina espacios en blanco al final de línea |
+| `end-of-file-fixer` | Garantiza que cada archivo termine con un salto de línea |
+| `check-yaml` | Valida la sintaxis de los archivos YAML |
+| `no-commit-to-branch` | Bloquea commits directos en `main` |
+| `clang-format` | Formatea el código C++ según `.clang-format` del proyecto |
+
+> [!NOTE] Si `clang-format` modifica archivos en un commit, el commit será
+> rechazado. Revisar los cambios con `git diff`, hacer `git add` de los archivos
+> ya formateados y volver a hacer el commit.
+
+### Ejecutar manualmente
+
+```bash
+# Verificar todos los archivos del repositorio
+pre-commit run --all-files
+
+# Verificar solo los archivos modificados
+pre-commit run
+```
+
+---
+
 ## Flujo de trabajo
 
 ### 1. Haz fork del repositorio


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega `.pre-commit-config.yaml` con hooks de calidad y formateo de código C++, y documenta el proceso de instalación en `CONTRIBUTING.md`.

## Cambios introducidos

### `.pre-commit-config.yaml` (nuevo)

Configura dos repositorios de hooks:

**`pre-commit/pre-commit-hooks` (v5.0.0):**
- `trailing-whitespace` — elimina espacios al final de línea
- `end-of-file-fixer` — garantiza que cada archivo termine con un salto de línea
- `check-yaml` — valida la sintaxis de todos los archivos YAML del repo
- `no-commit-to-branch` — bloquea commits directos en `main`

**Hook local `clang-format`:**
- Ejecuta `clang-format -i` sobre archivos `.cpp`, `.hpp`, `.cc`, `.cxx` y `.h`
- Usa el `.clang-format` existente en la raíz del repositorio (`BasedOnStyle: LLVM`, `IndentWidth: 2`)
- `language: system` para usar el `clang-format` instalado en la máquina del developer, sin instalar versiones adicionales

### `CONTRIBUTING.md` (modificado)

Agrega una nueva sección **"Configuración del entorno de desarrollo"** antes del flujo de trabajo existente, con:
- Requisitos (`clang-format`, Python 3.x)
- Instrucciones de instalación en Ubuntu/Debian y macOS
- Comando `pre-commit install` con nota de que se ejecuta una sola vez
- Tabla con los cinco hooks y su descripción
- Instrucciones para ejecutar manualmente con `pre-commit run --all-files`

## Notas

Se usa `language: system` en el hook local de `clang-format` para que cada developer use la versión de `clang-format` instalada en su sistema, que es la misma que usará en su flujo de desarrollo habitual. Esto evita conflictos entre versiones y es consistente con cómo el CI del proyecto instala `clang-format` vía `apt-get`.

## Issue relacionado
Closes #326 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde