### PR TITLE
chore: add loadavg and procesos collectors to CMake build - Closes #298

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ add_subdirectory(src)
 # add_subdirectory(src/collectors/network)
 # add_subdirectory(src/alertas)
 # add_subdirectory(src/config)
+# add_subdirectory(src/collectors/temperatura)   # pendiente: sin archivos fuente aún
+# add_subdirectory(src/collectors/uptime)        # pendiente: sin archivos fuente aún
 
 if(BUILD_TESTS)
     add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,8 @@ target_sources(pulso PRIVATE
     formatters/formatter_json.cpp
     formatters/formatter_prometheus.cpp
     http/handler_history.cpp
+    collectors/loadavg/loadavg_collector.cpp
+    collectors/procesos/proc_collector.cpp
     platform/linux/collector_cpu.cpp
     sampler/sampler.cpp
     storage/schema.cpp


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza `src/CMakeLists.txt` para incluir los dos collectors nuevos que existen en el repositorio pero no estaban referenciados en el build: `loadavg` y `procesos`. Actualiza `CMakeLists.txt` raíz con entradas comentadas para `temperatura` y `uptime`, siguiendo el mismo patrón ya establecido en el proyecto para directorios pendientes de implementación.

## Cambios introducidos

### `src/CMakeLists.txt`
Agregadas dos entradas a `target_sources(pulso PRIVATE ...)`:
```cmake
collectors/loadavg/loadavg_collector.cpp
collectors/procesos/proc_collector.cpp
```

### `CMakeLists.txt` (raíz)
Agregadas dos líneas comentadas al bloque de subdirectorios pendientes:
```cmake
# add_subdirectory(src/collectors/temperatura)   # pendiente: sin archivos fuente aún
# add_subdirectory(src/collectors/uptime)        # pendiente: sin archivos fuente aún
```

## Por qué solo loadavg y procesos

La issue menciona cuatro directorios: `procesos/`, `temperatura/`, `uptime/` y `loadavg/`. Al clonar la rama `dev` se verificó que **solo existen archivos fuente en `loadavg/` y `procesos/`**. Los directorios `temperatura/` y `uptime/` no tienen ningún `.cpp` ni `.hpp`. Agregar un `target_sources` apuntando a archivos inexistentes provocaría un error de CMake, por lo que se documentan como pendientes siguiendo el patrón ya establecido en el proyecto.

## Issue relacionado
Closes #298 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde