### PR TITLE
chore: crear tests/datos/entrada/sample_config.toml para tests de config.cpp - Closes#327

### DIFF
--- a/tests/datos/entrada/sample_config.toml
+++ b/tests/datos/entrada/sample_config.toml
@@ -1,0 +1,4 @@
+interval_ms = 500
+http_port = 9090
+log_level = 'debug'
+output_format = 'csv'


### PR DESCRIPTION
## ¿Qué hace este PR?
Se crea el archivo `tests/datos/entrada/sample_config.toml` con valores de prueba conocidos para los tests de `config.cpp`.

Los valores difieren intencionalmente de los defaults del sistema para permitir verificar que la carga de configuración funciona correctamente.

## Cambios

- `tests/datos/entrada/sample_config.toml` (nuevo)

## Issue relacionado
Closes #327

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde