### PR TITLE
docs: agregar sección Inicio Rápido en README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 Plataforma en C++ para gestionar y monitorear información clave de forma eficiente.
 
+## Inicio Rápido
+
+```bash
+sudo apt install git cmake g++
+git clone https://github.com/sis-inf/pulso.git && cd pulso
+cmake -S . -B build && cmake --build build
+./build/pulso --once
+```
+
+Salida esperada:
+
+```text
+Estado del sistema: OK
+```
+
+
 ## ¿Qué es?
 
 Pulso es una aplicación desarrollada en C++ que permite gestionar y visualizar información relevante de manera centralizada. Está pensada para ofrecer alto rendimiento y control directo sobre los recursos del sistema.


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega una sección **Inicio Rápido** al comienzo del README con los comandos básicos para instalar dependencias, clonar el repositorio, compilar el proyecto y ejecutar `pulso --once`.

## Issue relacionado

Closes #388

## Tipo de cambio

* [x] docs — documentación

## Checklist

* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente

## Evidencia / capturas

Se agregó la sección "Inicio Rápido" al inicio del README sin eliminar contenido existente.
