### PR TITLE
feat(tests): agregar fixture proc_meminfo_sample para tests de Collec…

### DIFF
--- a/tests/fixtures/proc_meminfo_sample
+++ b/tests/fixtures/proc_meminfo_sample
@@ -1,0 +1,8 @@
+MemTotal:        8192000 kB
+MemFree:         2048000 kB
+MemAvailable:    3072000 kB
+Buffers:          512000 kB
+Cached:          1024000 kB
+SwapCached:            0 kB
+Active:          4124312 kB
+Inactive:        1532104 kB


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el archivo fixture `proc_meminfo_sample` en la ruta `tests/fixtures/` para emular el comportamiento del archivo del sistema `/proc/meminfo` de Linux. Esto proporciona un entorno de datos estático, consistente y controlado para llevar a cabo las pruebas unitarias del componente `CollectorMemory` sin necesidad de interactuar con los recursos reales del sistema operativo.

El archivo define de forma precisa los campos obligatorios solicitados (`MemTotal`, `MemFree` y `MemAvailable`) expresados en kB, manteniendo la consistencia en la alineación de columnas mediante espacios en blanco y respetando la regla matemática del negocio donde la memoria disponible es menor o igual a la memoria total.

## Issue relacionado
Closes #296

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se verificó que el formateo de cadenas con espaciados y sufijos 'kB' coincide fielmente con el formato real de Linux. Asimismo, los valores numéricos fueron validados lógicamente cumpliendo con las restricciones dadas.
<img width="710" height="288" alt="image" src="https://github.com/user-attachments/assets/d3774446-29b9-4b53-b699-5ef35c8b37e6" />
