### PR TITLE
docs: agregar clang-format y ctest al flujo pre-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,8 @@ A partir de ese momento, cada `git commit` ejecutará automáticamente:
 > rechazado. Revisar los cambios con `git diff`, hacer `git add` de los archivos
 > ya formateados y volver a hacer el commit.
 
+
+
 ### Ejecutar manualmente
 
 ```bash
@@ -57,6 +59,20 @@ pre-commit run --all-files
 # Verificar solo los archivos modificados
 pre-commit run
 ```
+
+### Verificaciones antes de hacer commit
+
+Antes de crear un commit, asegúrate de:
+
+```bash
+# Formatear el archivo modificado
+clang-format -i src/archivo_modificado.cpp
+
+# Ejecutar las pruebas
+ctest --output-on-failure
+```
+
+Estas verificaciones ayudan a garantizar que el código cumpla con el formato del proyecto y que las pruebas continúen pasando correctamente.
 
 ---
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza `CONTRIBUTING.md` para incluir las verificaciones recomendadas antes de realizar un commit.

Se agregan los comandos:

* `clang-format -i src/archivo_modificado.cpp`
* `ctest --output-on-failure`

También se verificó que la instrucción `pre-commit install` ya estuviera incluida en la documentación.

## Issue relacionado

Closes #377

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [x] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

Se actualizó `CONTRIBUTING.md` agregando los comandos requeridos para formateo y verificación antes de realizar commits.
