### PR TITLE
feat(http): implementar handler_metrics — endpoint GET /metrics con snapshot actual - Closes#270

### DIFF
--- a/src/http/handler_metrics.cpp
+++ b/src/http/handler_metrics.cpp
@@ -5,46 +5,43 @@
 
 namespace pulso::http {
 
-void registrarMetrics(
-    httplib::Server&                       servidor,
-    const pulso::storage::Storage&         storage,
-    const pulso::formatters::IFormatter&   formatter)
+void HandleMetrics(
+  httplib::Server& servidor,
+  SystemMonitor&   system_monitor)
 {
-    servidor.Get("/metrics", [&storage, &formatter](
-        const httplib::Request&  req,
-        httplib::Response&       res)
-    {
-        auto& logger = pulso::utils::logging::Logger::instancia();
+  servidor.Get("/metrics", [&system_monitor](
+    const httplib::Request& req,
+    httplib::Response&      res)
+  {
+    auto& logger = pulso::utils::logging::Logger::instancia();
 
-        // Obtener el snapshot más reciente
-        auto snapshot = storage.last();
+    auto metrics = system_monitor.getMetrics();
 
-        int statusCode = 0;
+    int status_code = 0;
 
-        if (snapshot.has_value()) {
-            // Hay datos: responder con 200 y el body del formatter
-            std::string body        = formatter.formatear(snapshot.value());
-            std::string contentType = formatter.contentType();
+    if (!metrics.empty()) {
+      pulso::formatters::FormatterJSON formatter;
 
-            res.set_content(body, contentType);
-            res.status = 200;
-            statusCode = 200;
-        } else {
-            // No hay datos: responder con 503
-            res.set_content(
-                R"({ "error": "sin datos disponibles" })",
-                "application/json"
-            );
-            res.status = 503;
-            statusCode = 503;
-        }
+      std::string body         = formatter.formatear(metrics);
+      std::string content_type = formatter.contentType();
 
-        // Registrar la request en el log con nivel INFO
-        logger.info(
-            req.method + " " + req.path +
-            " -> " + std::to_string(statusCode)
-        );
-    });
+      res.set_content(body, content_type);
+      res.status = 200;
+      status_code = 200;
+    } else {
+      res.set_content(
+        R"({ "error": "no data available" })",
+        "application/json"
+      );
+      res.status = 503;
+      status_code = 503;
+    }
+
+    logger.info(
+      req.method + " " + req.path +
+      " -> " + std::to_string(status_code)
+    );
+  });
 }
 
 } // namespace pulso::http

--- a/src/http/handler_metrics.cpp
+++ b/src/http/handler_metrics.cpp
@@ -2,6 +2,10 @@
 #include "utils/logging/logger.hpp"
 
 #include <string>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+#include <ctime>
 
 namespace pulso::http {
 
@@ -16,6 +20,12 @@ void HandleMetrics(
     auto& logger = pulso::utils::logging::Logger::instancia();
 
     auto metrics = system_monitor.getMetrics();
+
+    auto now = std::chrono::system_clock::now();
+    std::time_t now_time_t = std::chrono::system_clock::to_time_t(now);
+    std::stringstream ss;
+    ss << std::put_time(std::gmtime(&now_time_t), "%Y-%m-%dT%H:%M:%SZ");
+    metrics["timestamp"] = ss.str();
 
     int status_code = 0;
 

--- a/src/http/handler_metrics.hpp
+++ b/src/http/handler_metrics.hpp
@@ -1,30 +1,28 @@
 #pragma once
 
 #include <httplib.h>
-#include "storage/storage.hpp"
-#include "formatters/iformatter.hpp"
+#include "../core/SystemMonitor.hpp"
+#include "../formatters/formatter_json.hpp"
 
 namespace pulso::http {
 
 /**
  * @brief Registra el handler del endpoint GET /metrics en el servidor HTTP.
  *
- * El handler devuelve el snapshot más reciente almacenado en la base de datos,
- * formateado según el formatter proporcionado.
+ * El handler retorna el snapshot más reciente obtenido directamente desde
+ * SystemMonitor, serializado como JSON usando FormatterJSON.
  *
- * - Si hay datos: responde con HTTP 200 y el body producido por el formatter.
+ * - Si hay datos: responde con HTTP 200 y el body en JSON.
  * - Si no hay datos: responde con HTTP 503 y un JSON de error.
  *
  * Cada request se registra en el log con nivel INFO incluyendo
  * método, ruta y código de respuesta.
  *
- * @param servidor  Referencia al servidor httplib donde se registra el handler.
- * @param storage   Referencia al almacenamiento para obtener el último snapshot.
- * @param formatter Referencia al formatter que serializa el snapshot.
+ * @param servidor       Referencia al servidor httplib donde se registra el handler.
+ * @param system_monitor Referencia al monitor del sistema para obtener las métricas actuales.
  */
-void registrarMetrics(
-    httplib::Server&                       servidor,
-    const pulso::storage::Storage&         storage,
-    const pulso::formatters::IFormatter&   formatter);
+void HandleMetrics(
+  httplib::Server& servidor,
+  SystemMonitor&   system_monitor);
 
 } // namespace pulso::http


### PR DESCRIPTION
## ¿Qué hace este PR?
Actualiza la implementación de `handler_metrics` para alinearse con lo solicitado en el issue #270.  Se añade un campo `timestamp` en formato ISO-8601 (UTC) al JSON que devuelve el endpoint `GET /metrics`.

## Cambios realizados
- `src/http/handler_metrics.hpp`
- `src/http/handler_metrics.cpp`

## Qué se modificó respecto a la versión anterior
- La función ahora se llama `HandleMetrics` siguiendo la guía de estilo del proyecto (PascalCase)
- Recibe `SystemMonitor&` en lugar de `Storage` e `IFormatter`, tal como pedía el issue
- Usa `FormatterJSON` directamente en lugar de `IFormatter`, garantizando que la respuesta sea JSON
- Las métricas se obtienen desde `system_monitor.getMetrics()` en lugar de `storage.last()`
- Variables renombradas a `snake_case` según guía de estilo
- Comentarios de documentación en español, código fuente en inglés

## Issue relacionado
Closes #270 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde