### PR TITLE
docs: expandir monitor-config.md con alertas y opciones CLI

### DIFF
--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -26,3 +26,57 @@ Se sugiere que la estructura contenga:
 ## Nota
 
 Esta es solo una propuesta en documentación. No se está implementando código fuente aún.
+
+## Configuración de alertas
+
+Se propone agregar una sección de alertas en el archivo de configuración para definir umbrales máximos de uso de recursos.
+
+Ejemplo:
+
+[alertas]
+
+- cpu.max = 90
+- ram.max = 80
+- disco.max = 85
+
+Donde:
+
+- cpu.max: porcentaje máximo permitido de uso de CPU
+- ram.max: porcentaje máximo permitido de uso de memoria RAM
+- disco.max: porcentaje máximo permitido de uso de disco
+
+Cuando una métrica supera el valor configurado, el sistema puede generar una alerta para notificar al usuario.
+
+## Modo de ejecución única
+
+El parámetro `--once` permite ejecutar una única lectura de métricas y finalizar inmediatamente después de completar la ejecución.
+
+Ejemplo:
+
+- pulso --once
+
+## Opciones de línea de comandos
+
+### --port
+
+Permite especificar el puerto utilizado por el servicio.
+
+Ejemplo:
+
+- pulso --port 8080
+
+### --format
+
+Permite seleccionar el formato de salida.
+
+Ejemplo:
+
+- pulso --format json
+
+### --config
+
+Permite indicar un archivo de configuración personalizado.
+
+Ejemplo:
+
+- pulso --config pulso.toml


### PR DESCRIPTION
## ¿Qué hace este PR?
- Agrega documentación de configuración de alertas.
- Incluye ejemplos de cpu.max, ram.max y disco.max.
- Documenta la opción --once.
- Documenta las opciones --port, --format y --config.
- Mantiene intacto el contenido existente del documento.

## Issue relacionado
Closes #384

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas