### PR TITLE
chore(tests): agregar fixture proc_net_dev_sample para CollectorNetwork

### DIFF
--- a/tests/fixtures/proc_net_dev_sample
+++ b/tests/fixtures/proc_net_dev_sample
@@ -1,0 +1,5 @@
+Inter-|   Receive                                                |  Transmit
+ face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+    lo: 1000    10      0    0    0    0     0          0         1000    10      0    0    0    0     0       0
+  eth0: 500000  5000    0    0    0    0     0          0         300000  3000    0    0    0    0     0       0
+ wlan0: 250000  2500    0    0    0    0     0          0         150000  1500    0    0    0    0     0       0


### PR DESCRIPTION
## ¿Qué hace este PR?
El fixture contiene datos simulados con el formato de `/proc/net/dev`, incluyendo las interfaces:
- lo
- eth0
- wlan0

Además, se agregan valores fijos y conocidos para `rx_bytes` y `tx_bytes`, permitiendo validar correctamente los cálculos realizados en los tests.

## Issue relacionado
Closes #318

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Se agregó el fixture `tests/fixtures/proc_net_dev_sample` con datos simulados para pruebas de `CollectorNetwork`.