### PR TITLE
test: agregar tests para config completo

### DIFF
--- a/tests/automatizados/unit/test_config_completo.cpp
+++ b/tests/automatizados/unit/test_config_completo.cpp
@@ -1,0 +1,83 @@
+#include <gtest/gtest.h>
+#include <fstream>
+#include <filesystem>
+
+#include "config/config.hpp"
+
+namespace fs = std::filesystem;
+
+class ConfigCompletoTest : public ::testing::Test {
+protected:
+    std::string archivo_;
+
+    void SetUp() override {
+        archivo_ =
+            std::string(::testing::UnitTest::GetInstance()
+                            ->current_test_info()
+                            ->name()) +
+            ".toml";
+    }
+
+    void TearDown() override {
+        if (fs::exists(archivo_)) {
+            fs::remove(archivo_);
+        }
+    }
+};
+
+TEST_F(ConfigCompletoTest, ValoresPorDefecto)
+{
+    auto cfg = pulso::config::porDefecto();
+
+    EXPECT_EQ(cfg.servidor.puerto, 8080);
+    EXPECT_EQ(cfg.sampler.intervalo_segundos, 10);
+}
+
+TEST_F(ConfigCompletoTest, CargaArchivoValido)
+{
+    std::ofstream out(archivo_);
+
+    out
+        << "[servidor]\n"
+        << "puerto = 9090\n"
+        << "\n"
+        << "[sampler]\n"
+        << "intervalo_segundos = 5\n";
+
+    out.close();
+
+    auto cfg = pulso::config::cargar(archivo_);
+
+    EXPECT_EQ(cfg.servidor.puerto, 9090);
+    EXPECT_EQ(cfg.sampler.intervalo_segundos, 5);
+}
+
+TEST_F(ConfigCompletoTest, IntervaloInvalidoLanzaExcepcion)
+{
+    std::ofstream out(archivo_);
+
+    out
+        << "[sampler]\n"
+        << "intervalo_segundos = -1\n";
+
+    out.close();
+
+    EXPECT_THROW(
+        pulso::config::cargar(archivo_),
+        std::invalid_argument
+    );
+}
+
+TEST_F(ConfigCompletoTest, CampoDesconocidoSeIgnora)
+{
+    std::ofstream out(archivo_);
+
+    out
+        << "campo_inexistente = 123\n";
+
+    out.close();
+
+    EXPECT_NO_THROW(
+        pulso::config::cargar(archivo_)
+    );
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega tests automatizados para la configuración.

Incluye pruebas para:

- Valores por defecto.
- Carga de configuración desde archivo temporal.
- Validación de valores inválidos.
- Ignorar campos desconocidos.

## Issue relacionado
Closes #313

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas