### PR TITLE
fix(docs): agregar requerimientos no funcionales de rendimiento #366

### DIFF
--- a/docs/requerimientos.md
+++ b/docs/requerimientos.md
@@ -34,6 +34,13 @@ Los siguientes requerimientos definen las restricciones técnicas y de calidad b
 | **RNF-011** | Mantenibilidad | La cobertura de pruebas unitarias debe ser al menos del **80%** en cada release. | Media |
 md
 
+
+| RNF-012 | Rendimiento | Consumo máximo de CPU: < 2% de un solo núcleo en operación normal | Alta |
+| RNF-013 | Rendimiento | Consumo máximo de memoria RAM: < 50 MB en estado estable | Alta |
+| RNF-014 | Rendimiento | Latencia máxima del endpoint /metrics: < 50 ms | Alta |
+| RNF-015 | Rendimiento | Tiempo máximo de inicio del agente: < 2 segundos | Alta |
+| RNF-016 | Disponibilidad | Disponibilidad anual del servicio: 99.9% de tiempo activo | Alta |
+
 ## Requerimientos de Sistema
 
 | ID | Descripción |


### PR DESCRIPTION
5 requerimientos no funcionales de rendimiento con valores numéricos concretos:
- Consumo máximo CPU < 2% de un núcleo
- Consumo máximo RAM < 50 MB
- Latencia endpoint /metrics < 50 ms
- Tiempo de inicio < 2 segundos
- Disponibilidad 99.9%

No se modificó contenido existente.

## ¿Qué hace este PR?

Agrega 5 requerimientos no funcionales de rendimiento con valores numéricos:
 - Consumo máximo CPU: < 2% de un núcleo
 - Consumo máximo RAM: < 50 MB
 - Latencia endpoint /metrics: < 50 ms
 - Tiempo de inicio: < 2 segundos
 - Disponibilidad: 99.9% de uptime
 No se modificó ni borró contenido anterior.

## Issue relacionado
Closes #366

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [X ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [X ] Mi código sigue los estándares del proyecto
- [ X] Actualicé la documentación correspondiente
- [ X] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas