### PR TITLE
feat(core): implement addCollector and collectAll in SystemMonitor - Closes #288

### DIFF
--- a/src/core/SystemMonitor.cpp
+++ b/src/core/SystemMonitor.cpp
@@ -1,51 +1,144 @@
 #include "SystemMonitor.hpp"
 
 #include <chrono>
+#include <iostream>
 #include <map>
 #include <string>
 
-// Declaraciones de funciones existentes
+// ─── Declaraciones de funciones del flujo legacy ─────────────────────────────
+
+/// @brief Obtiene el porcentaje de uso de CPU leyendo /proc/stat.
 double ObtenerUsoCPU();
+
+/// @brief Obtiene el porcentaje de uso de disco.
 double getDiskUsage();
+
+/// @brief Obtiene el porcentaje de uso de RAM.
 double getRAMUsage();
 
+/**
+ * @brief Agrupa bytes de entrada y salida de la interfaz de red principal.
+ */
 struct NetworkIO {
-    long rx;
-    long tx;
+    long rx; ///< Bytes recibidos
+    long tx; ///< Bytes enviados
 };
 
+/// @brief Obtiene los contadores de red del sistema.
 NetworkIO getNetworkIO();
 
+// Implementación de SystemMonitor
+/**
+ * @brief Inicializa el monitor con estado detenido y lista de collectors vacía.
+ */
 SystemMonitor::SystemMonitor()
-    : running(false) {
+    : running_(false) {
 }
 
+// ─────────────────────────── API principal ───────────────────────────────────
+
+/**
+ * @brief Agrega un collector a la lista interna.
+ *
+ * El collector se almacena como shared_ptr. Se puede llamar antes o después
+ * de start() sin efecto sobre el estado del monitor.
+ *
+ * @param collector  Implementación de ICollector a registrar. No debe ser
+ *                   nullptr; de serlo, el comportamiento es indefinido.
+ */
+void SystemMonitor::addCollector(
+    std::shared_ptr<pulso::collectors::ICollector> collector)
+{
+    collectors_.push_back(std::move(collector));
+}
+
+/**
+ * @brief Ejecuta todos los collectors y combina sus métricas en un Snapshot.
+ *
+ * Toma el timestamp Unix una sola vez al inicio del ciclo para que todas las
+ * métricas compartan el mismo instante de captura. Por cada collector:
+ *  - Invoca recolectar().
+ *  - Inserta las Metrica devueltas al final del vector del snapshot.
+ *  - Si el collector lanza std::exception, imprime el error en stderr y
+ *    continúa con el siguiente (fail-safe).
+ *
+ * Un monitor sin collectors registrados retorna un Snapshot con timestamp
+ * actual y vector de métricas vacío, sin lanzar ninguna excepción.
+ *
+ * @return Snapshot consolidado con métricas de todos los collectors activos.
+ */
+pulso::core::Snapshot SystemMonitor::collectAll() {
+    pulso::core::Snapshot snapshot;
+    snapshot.timestamp = static_cast<std::int64_t>(
+        std::chrono::duration_cast<std::chrono::seconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        ).count()
+    );
+
+    for (const auto& collector : collectors_) {
+        try {
+            auto metricas = collector->recolectar();
+            snapshot.metricas.insert(
+                snapshot.metricas.end(),
+                metricas.begin(),
+                metricas.end()
+            );
+        } catch (const std::exception& e) {
+            std::cerr << "[SystemMonitor] Error en collector \""
+                      << collector->nombre()
+                      << "\": " << e.what() << "\n";
+        }
+    }
+
+    return snapshot;
+}
+
+// ─────────────────────────── API legacy ──────────────────────────────────────
+
+/**
+ * @brief Activa el monitor y ejecuta una captura con los collectors legacy.
+ *
+ * Mantiene el comportamiento original: llama a las funciones libres
+ * ObtenerUsoCPU(), getRAMUsage(), getDiskUsage() y getNetworkIO() para
+ * rellenar el mapa interno metrics_. Se conserva para compatibilidad con
+ * handler_metrics.cpp hasta que ese módulo migre al flujo ICollector.
+ *
+ * @deprecated Preferir addCollector() + collectAll() para nuevas integraciones.
+ */
 void SystemMonitor::start() {
+    running_ = true;
 
-    running = true;
+    const auto inicio = std::chrono::steady_clock::now();
 
-    auto inicio = std::chrono::steady_clock::now();
+    metrics_["cpu"]  = ObtenerUsoCPU();
+    metrics_["ram"]  = getRAMUsage();
+    metrics_["disk"] = getDiskUsage();
 
-    metrics["cpu"] = ObtenerUsoCPU();
-    metrics["ram"] = getRAMUsage();
-    metrics["disk"] = getDiskUsage();
+    const NetworkIO net = getNetworkIO();
+    metrics_["net.rx"] = static_cast<double>(net.rx);
+    metrics_["net.tx"] = static_cast<double>(net.tx);
 
-    NetworkIO net = getNetworkIO();
-
-    metrics["net.rx"] = static_cast<double>(net.rx);
-    metrics["net.tx"] = static_cast<double>(net.tx);
-
-    auto fin = std::chrono::steady_clock::now();
-
-    auto duracion = fin - inicio;
+    [[maybe_unused]] const auto duracion =
+        std::chrono::steady_clock::now() - inicio;
 }
 
+/**
+ * @brief Marca el monitor como detenido.
+ *
+ * @deprecated Parte de la API legacy; sin efecto sobre addCollector/collectAll.
+ */
 void SystemMonitor::stop() {
-
-    running = false;
+    running_ = false;
 }
 
+/**
+ * @brief Retorna el mapa de métricas de la última llamada a start().
+ *
+ * @return Copia del mapa interno metrics_.
+ *
+ * @deprecated Preferir collectAll() que retorna un Snapshot tipado con
+ *             todas las métricas de los collectors registrados.
+ */
 std::map<std::string, double> SystemMonitor::getMetrics() const {
-
-    return metrics;
+    return metrics_;
 }

--- a/src/core/SystemMonitor.hpp
+++ b/src/core/SystemMonitor.hpp
@@ -1,23 +1,131 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
+#include <vector>
 
+#include "collectors/icollector.hpp"
+#include "core/types.hpp"
+
+/**
+ * @brief Orquestador de métricas del sistema basado en collectors dinámicos.
+ *
+ * Mantiene una lista interna de collectors registrados vía addCollector().
+ * Al llamar a collectAll(), itera sobre ellos, combina todas sus métricas
+ * en un único pulso::core::Snapshot y lo retorna.
+ *
+ * Los errores de un collector individual se capturan y registran en stderr
+ * sin interrumpir los demás (fail-safe).
+ *
+ * @note La API legacy start() / stop() / getMetrics() se conserva para
+ *       compatibilidad con handler_metrics.cpp hasta que ese módulo
+ *       migre al flujo Sampler + Storage.
+ */
 class SystemMonitor {
-
-private:
-
-    bool running;
-
-    std::map<std::string, double> metrics;
 
 public:
 
+    // ─────────────────────────── ciclo de vida ───────────────────────────────
+
+    /**
+     * @brief Constructor por defecto.
+     *
+     * Inicializa el monitor en estado detenido y con la lista de collectors
+     * vacía. Es seguro llamar a addCollector() antes o después de start().
+     */
     SystemMonitor();
 
+    // ─────────────────────────── API principal ───────────────────────────────
+
+    /**
+     * @brief Registra un collector en la lista interna del monitor.
+     *
+     * El collector es almacenado como shared_ptr, por lo que el monitor
+     * comparte la propiedad. Se puede llamar en cualquier momento, incluso
+     * con el monitor en ejecución.
+     *
+     * @param collector  Puntero compartido a cualquier implementación de
+     *                   pulso::collectors::ICollector. No debe ser nullptr.
+     *
+     * @pre  `collector != nullptr`
+     * @post El collector queda registrado y será invocado en el próximo
+     *       collectAll().
+     *
+     * @see pulso::collectors::ICollector
+     * @see collectAll()
+     */
+    void addCollector(std::shared_ptr<pulso::collectors::ICollector> collector);
+
+    /**
+     * @brief Ejecuta todos los collectors registrados y combina sus métricas.
+     *
+     * Itera sobre la lista interna de collectors en orden de registro.
+     * Por cada collector:
+     *  - Llama a ICollector::recolectar().
+     *  - Añade las métricas devueltas al vector del snapshot.
+     *  - Si el collector lanza una excepción, la captura, la registra en
+     *    stderr y continúa con el siguiente (comportamiento fail-safe).
+     *
+     * Si no hay collectors registrados, retorna un snapshot vacío con el
+     * timestamp actual y un vector de métricas vacío (sin crash).
+     *
+     * @return pulso::core::Snapshot con todas las métricas combinadas y el
+     *         timestamp Unix del momento de la llamada.
+     *
+     * @note El timestamp se toma una sola vez al inicio de la iteración para
+     *       que todas las métricas del snapshot compartan el mismo instante.
+     *
+     * @see addCollector()
+     * @see pulso::core::Snapshot
+     */
+    pulso::core::Snapshot collectAll();
+
+    // ─────────────────────────── API legacy ──────────────────────────────────
+
+    /**
+     * @brief Marca el monitor como activo y ejecuta una captura inicial.
+     *
+     * Invoca los collectors hardcodeados legacy (CPU, RAM, disco, red)
+     * y rellena el mapa interno `metrics`. Se conserva para compatibilidad
+     * con handler_metrics.cpp.
+     *
+     * @deprecated Preferir addCollector() + collectAll() para nuevas
+     *             integraciones.
+     */
     void start();
 
+    /**
+     * @brief Marca el monitor como detenido.
+     *
+     * @deprecated Parte de la API legacy. Sin efecto en el flujo de
+     *             addCollector() / collectAll().
+     */
     void stop();
 
+    /**
+     * @brief Retorna el mapa de métricas de la última captura legacy.
+     *
+     * @return Mapa nombre → valor de la última llamada a start().
+     *
+     * @deprecated Preferir collectAll() que retorna un Snapshot tipado.
+     */
     std::map<std::string, double> getMetrics() const;
+
+private:
+
+    /** @brief Indica si el monitor está en estado activo (API legacy). */
+    bool running_;
+
+    /**
+     * @brief Lista de collectors registrados dinámicamente.
+     *
+     * Se itera en orden de registro dentro de collectAll().
+     * Protegida por convención; no se usa mutex ya que SystemMonitor
+     * no está diseñado para acceso concurrente en esta versión.
+     */
+    std::vector<std::shared_ptr<pulso::collectors::ICollector>> collectors_;
+
+    /** @brief Mapa de métricas de la API legacy (usado por getMetrics()). */
+    std::map<std::string, double> metrics_;
 };


### PR DESCRIPTION
## ¿Qué hace este PR?

Expande `SystemMonitor` (que tenía 917 bytes y era básico) para soportar el registro dinámico de collectors vía `addCollector()` y la ejecución consolidada de todos ellos a través de `collectAll()`, sin hardcodear ningún tipo específico de collector.

## Cambios

### `src/core/SystemMonitor.hpp` _(modificado)_
- Nuevo método público `addCollector(std::shared_ptr<ICollector>)`
- Nuevo método público `collectAll()` → retorna `pulso::core::Snapshot`
- Lista interna `collectors_` (`vector<shared_ptr<ICollector>>`)
- Renombrado `running` → `running_` y `metrics` → `metrics_` (convención de miembros privados)
- API legacy `start()` / `stop()` / `getMetrics()` marcada `@deprecated` y conservada intacta

### `src/core/SystemMonitor.cpp` _(modificado)_
- Implementación de `addCollector()`: almacena el collector con `push_back(std::move(...))`
- Implementación de `collectAll()`: toma timestamp una sola vez, itera `collectors_`, acumula métricas y captura excepciones por collector (fail-safe)
- API legacy sin cambios funcionales respecto a la versión original

---

## Comportamiento de collectAll()

```
SystemMonitor monitor;
monitor.addCollector(make_shared<CollectorCPU>());
monitor.addCollector(make_shared<CollectorMemory>());

pulso::core::Snapshot snap = monitor.collectAll();
// snap.metricas contiene las métricas de CPU + RAM combinadas
```

**Fail-safe:** si un collector lanza `std::exception`, el error se registra en `stderr` y la iteración continúa con el siguiente:
```
[SystemMonitor] Error en collector "faulty": fallo simulado
```

## Tests de humo ejecutados

| Escenario | Resultado |
|---|---|
| Sin collectors → `collectAll()` | Snapshot vacío, sin crash ✅ |
| Dos collectors (CPU + RAM) → 3 métricas combinadas | ✅ |
| Collector que lanza excepción → collector siguiente continúa | ✅ |

## Issue relacionado
Closes #288 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde