### PR TITLE
feat(http): implement handler_config - GET /config endpoint - Closes #283

### DIFF
--- a/src/http/handler_config.cpp
+++ b/src/http/handler_config.cpp
@@ -1,0 +1,55 @@
+#include "handler_config.hpp"
+
+#include <sstream>
+#include <string>
+
+namespace pulso::http {
+
+/// Versión del agente Pulso, alineada con handler_health.cpp.
+static const std::string VERSION = "0.1.0";
+
+/**
+ * @brief Escapa caracteres especiales JSON en un string.
+ *
+ * Reemplaza `"` → `\"` y `\` → `\\` para evitar JSON malformado si algún
+ * campo de configuración contiene esos caracteres.
+ *
+ * @param s  String original.
+ * @return   String con caracteres especiales escapados.
+ */
+static std::string jsonEscape(const std::string& s) {
+    std::string out;
+    out.reserve(s.size());
+    for (const char c : s) {
+        if      (c == '"')  out += "\\\"";
+        else if (c == '\\') out += "\\\\";
+        else                out += c;
+    }
+    return out;
+}
+
+/**
+ * @brief Serializa los campos no sensibles de config en JSON.
+ *
+ * Convierte `sampler.intervalo_segundos` a milisegundos multiplicando por
+ * 1000, ya que la issue especifica el campo como `interval_ms`.
+ *
+ * @param config  Configuración activa de la instancia Pulso.
+ * @return        String JSON con los cinco campos públicos.
+ */
+std::string handleConfig(const pulso::config::Config& config) {
+    const int interval_ms = config.sampler.intervalo_segundos * 1000;
+
+    std::ostringstream json;
+    json << "{"
+         << "\"interval_ms\":"   << interval_ms                            << ","
+         << "\"http_port\":"     << config.servidor.puerto                 << ","
+         << "\"log_level\":\""   << jsonEscape(config.nivel_log)   << "\","
+         << "\"output_format\":\"" << jsonEscape(config.output_format) << "\","
+         << "\"version\":\""     << VERSION                               << "\""
+         << "}";
+
+    return json.str();
+}
+
+} // namespace pulso::http

--- a/src/http/handler_config.hpp
+++ b/src/http/handler_config.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+#include "config/config.hpp"
+
+namespace pulso::http {
+
+/**
+ * @brief Genera la respuesta JSON para el endpoint GET /config.
+ *
+ * Serializa los campos no sensibles de @p config en un objeto JSON plano.
+ * El campo `interval_ms` se obtiene convirtiendo
+ * `config.sampler.intervalo_segundos` a milisegundos (`× 1000`).
+ *
+ * Ejemplo de respuesta:
+ * @code
+ * {
+ *   "interval_ms": 10000,
+ *   "http_port": 8080,
+ *   "log_level": "info",
+ *   "output_format": "json",
+ *   "version": "0.1.0"
+ * }
+ * @endcode
+ *
+ * @param config  Configuración activa cargada por `pulso::config::cargar()`.
+ * @return        String con el JSON listo para enviar como cuerpo HTTP.
+ *
+ * @note  La función es pura (sin efectos secundarios) y thread-safe: puede
+ *        invocarse desde el callback de httplib sin sincronización adicional.
+ *
+ * @see pulso::config::Config
+ * @see pulso::config::cargar()
+ */
+std::string handleConfig(const pulso::config::Config& config);
+
+} // namespace pulso::http


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega los archivos `src/http/handler_config.hpp` y `src/http/handler_config.cpp` que implementan `handleConfig()`, función que retorna la configuración activa no sensible de la instancia Pulso en formato JSON. Útil para diagnóstico remoto sin necesidad de acceder al servidor.

## Cambios

### `src/http/handler_config.hpp` _(nuevo)_
- Declaración de `handleConfig(const pulso::config::Config&)` en `namespace pulso::http`
- `@note` indicando que la función es pura y thread-safe

### `src/http/handler_config.cpp` _(nuevo)_
- Implementación de `handleConfig()`: serializa los 5 campos no sensibles con `std::ostringstream`
- Helper interno `jsonEscape()` para escapar `"` y `\` en campos string
- `interval_ms` se obtiene como `sampler.intervalo_segundos × 1000`
- `version` hardcodeada a `"0.1.0"`, alineada con `handler_health.cpp`

---

## Respuesta JSON de ejemplo

```json
{
  "interval_ms": 10000,
  "http_port": 8080,
  "log_level": "info",
  "output_format": "json",
  "version": "0.1.0"
}
```

## Tests de humo ejecutados

| Escenario | Resultado |
|---|---|
| Config por defecto → 5 campos correctos, sin campos sensibles | ✅ |
| Config personalizada (puerto 9090, debug, prometheus) | ✅ |
| Campos string con `"` y `\` → escape JSON correcto | ✅ |

---

## Notas para el revisor

- El estilo de serialización JSON (manual con `ostringstream`) sigue el mismo patrón que `handler_health.cpp` para mantener consistencia sin agregar dependencias externas.
- `interval_ms` es la unidad pedida en la issue; internamente `Config` usa `intervalo_segundos`, la conversión `× 1000` se hace en el handler.
- Para registrar el endpoint en el servidor HTTP bastará agregar en `main.cpp`:
  ```cpp
  server.Get("/config", [&cfg](const httplib::Request&, httplib::Response& res) {
      res.set_content(pulso::http::handleConfig(cfg), "application/json");
  });
  ```
  Eso queda fuera del alcance de esta issue.

## Issue relacionado
Closes #283 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde