### PR TITLE
Agrega documentación de dependencias externas(#363)

### DIFF
--- a/docs/dependencias-externas.md
+++ b/docs/dependencias-externas.md
@@ -1,0 +1,104 @@
+# Dependencias Externas
+
+## Resumen
+
+El proyecto **Pulso** utiliza un conjunto mínimo de dependencias externas. La principal dependencia es Google Test, utilizada para la ejecución de pruebas automatizadas. No existen dependencias de ejecución (runtime) adicionales fuera de la biblioteca estándar de C++ y las llamadas al sistema proporcionadas por Linux.
+
+## Tabla de dependencias
+
+| Dependencia | Versión | Propósito | Instalación | Obligatoria |
+|-------------|----------|------------|-------------|-------------|
+| Google Test (gtest) | Repositorios Ubuntu | Pruebas unitarias | apt | Sí |
+| clang-format | Repositorios Ubuntu | Formateo de código | apt | No |
+| clang-tidy | Repositorios Ubuntu | Análisis estático | apt | No |                |
+
+---
+
+## Instalación de Google Test
+
+### Ubuntu 22.04
+
+Actualizar los repositorios:
+
+```bash
+sudo apt update
+```
+
+Instalar Google Test:
+
+```bash
+sudo apt install -y libgtest-dev
+```
+
+Verificar la instalación:
+
+```bash
+dpkg -l | grep gtest
+```
+
+### Ubuntu 24.04
+
+Actualizar los repositorios:
+
+```bash
+sudo apt update
+```
+
+Instalar Google Test:
+
+```bash
+sudo apt install -y libgtest-dev
+```
+
+Verificar la instalación:
+
+```bash
+dpkg -l | grep gtest
+```
+
+---
+
+## Instalación de clang-format
+
+### Ubuntu 22.04 y 24.04
+
+```bash
+sudo apt update
+sudo apt install -y clang-format
+```
+
+Verificar la instalación:
+
+```bash
+clang-format --version
+```
+
+---
+
+## Instalación de clang-tidy
+
+### Ubuntu 22.04 y 24.04
+
+```bash
+sudo apt update
+sudo apt install -y clang-tidy
+```
+
+Verificar la instalación:
+
+```bash
+clang-tidy --version
+```
+
+---
+
+## Dependencias de ejecución (Runtime)
+
+Pulso **no tiene dependencias de runtime externas**.
+
+La aplicación utiliza únicamente:
+
+* La biblioteca estándar de C++ (Standard Library).
+* Las llamadas al sistema (system calls) proporcionadas por Linux.
+
+Por lo tanto, no es necesario instalar bibliotecas adicionales para ejecutar la aplicación una vez compilada.


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega documentación de dependencias externas.

El documento incluye:

Tabla de dependencias.
Instrucciones de instalación de Google Test en Ubuntu 22.04 y 24.04.
Instrucciones de instalación de clang-format.
Instrucciones de instalación de clang-tidy.
Nota indicando que Pulso no posee dependencias de runtime externas.

Closes #363

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0774d3c0-bf79-431d-aafe-70e5346b82b9" />
