### PR TITLE
docs: agregar instrucciones de Google Test(386)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,33 @@ git push origin tipo/descripcion-corta
 - ✅ Todo PR necesita al menos una revisión
 
 ---
+## Verificación antes del PR
+
+Antes de abrir un Pull Request, verifica que el proyecto compile correctamente y que todas las pruebas pasen.
+
+### Compilar con soporte para Google Test
+
+```bash
+cmake -S . -B build -DBUILD_TESTS=ON
+cmake --build build
+```
+
+### Ejecutar todos los tests
+
+```bash
+cd build && ctest --output-on-failure
+```
+
+El parámetro `--output-on-failure` muestra información detallada cuando una prueba falla.
+
+### Ejecutar un test específico
+
+```bash
+ctest -R nombre_del_test
+```
+
+Reemplaza `nombre_del_test` por el nombre del test que deseas ejecutar.
+
 
 ## Ramas del proyecto
 


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR actualiza el archivo `CONTRIBUTING.md` para incluir instrucciones claras sobre la compilación y ejecución de pruebas con Google Test y CTest.

Se agregan comandos para:
- Compilar el proyecto con soporte de tests (`BUILD_TESTS=ON`)
- Ejecutar todos los tests con `ctest --output-on-failure`
- Ejecutar tests específicos con `ctest -R nombre_del_test`


## Issue relacionado
Closes #386

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x ] Mi código sigue los estándares del proyecto
- [ x] Actualicé la documentación correspondiente
- [ x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
![Uploading image.png…]()
