### PR TITLE
fix(docs): corregir nombres de configuración a español #384

### DIFF
--- a/docs/monitor-config.md
+++ b/docs/monitor-config.md
@@ -26,3 +26,27 @@ Se sugiere que la estructura contenga:
 ## Nota
 
 Esta es solo una propuesta en documentación. No se está implementando código fuente aún.
+
+# Configuración general del monitoreo
+[general]
+intervalo_recoleccion = 5    # Intervalo entre lecturas en segundos
+nivel_registro = "info"     # Nivel de detalle: debug, info, advertencia, error
+
+# Configuración de alertas
+[alertas]
+habilitado = true            # Activar/desactivar sistema de alertas
+intervalo_revision = 60      # Revisar condiciones cada 60 segundos
+
+# Umbrales para CPU
+[alertas.cpu]
+max = 90                     # Alerta si el uso supera el 90%
+lecturas_consecutivas = 3    # Activar después de 3 mediciones seguidas
+
+# Umbrales para memoria RAM
+[alertas.ram]
+max = 85                     # Alerta si el uso supera el 85%
+
+# Umbrales para disco
+[alertas.disco]
+max = 90                     # Alerta si el uso supera el 90%
+ruta = "/"                    # Ruta del disco a monitorear


### PR DESCRIPTION
Se ajustó la configuración de alertas para usar nombres en español tal como solicita el issue.

## ¿Qué hace este PR?
Se ajustó la configuración de alertas para usar nombres en español tal como solicita el issue, manteniendo el resto del contenido intacto.

## Issue relacionado
Closes #384

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ x] Mi código sigue los estándares del proyecto
- [x ] Actualicé la documentación correspondiente
- [ x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas