### PR TITLE
refactor(collectors/memory): add optional path parameter to getRamUsage() for mock support - Closes #449

### DIFF
--- a/src/collectors/memory/ram_usage.cpp
+++ b/src/collectors/memory/ram_usage.cpp
@@ -8,12 +8,12 @@
 
 namespace pulso::collectors::memory {
 
-RamInfo getRamUsage() {
-    std::ifstream file("/proc/meminfo");
+RamInfo getRamUsage(const std::string& path) {
+    std::ifstream file(path);
 
     if (!file.is_open()) {
         throw std::runtime_error(
-            "No se pudo abrir el archivo /proc/meminfo: "
+            "No se pudo abrir el archivo " + path + ": "
             "verifique permisos y disponibilidad del sistema"
         );
     }
@@ -40,7 +40,7 @@ RamInfo getRamUsage() {
 
     if (memTotal == 0 || memAvailable == 0) {
         throw std::runtime_error(
-            "No se encontraron las claves MemTotal o MemAvailable en /proc/meminfo"
+            "No se encontraron las claves MemTotal o MemAvailable en " + path
         );
     }
 

--- a/src/collectors/memory/ram_usage.hpp
+++ b/src/collectors/memory/ram_usage.hpp
@@ -25,9 +25,11 @@ struct RamInfo {
 
 /**
  * @brief Obtiene las metricas actuales de uso de memoria RAM del sistema.
+ * @param path Ruta al archivo de información de memoria (por defecto "/proc/meminfo").
+ *             Permite inyectar una ruta alternativa en tests sin modificar el código de producción.
  * @return RamInfo con los valores de memoria total, usada y disponible.
  */
-RamInfo getRamUsage();
+RamInfo getRamUsage(const std::string& path = "/proc/meminfo");
 
 /**
  * @brief Collector de métricas de memoria RAM.


### PR DESCRIPTION
## ¿Qué hace este PR?
Modifica la firma de `getRamUsage()` para aceptar un parámetro opcional `const std::string& path` con valor por defecto `"/proc/meminfo"`, eliminando la ruta hardcodeada en la implementación.

### Cambios

* `ram_usage.hpp` — nueva firma con parámetro opcional y documentación actualizada.
* `ram_usage.cpp` — implementación usa `path` en lugar del literal `/proc/meminfo`; los mensajes de error también incluyen la ruta real para facilitar el debug.

La firma anterior impedía inyectar una ruta alternativa en los tests sin tocar el código de producción. Con este cambio, `test_ram_usage.cpp` podrá llamar `getRamUsage(ruta_mock)` directamente.

### Compatibilidad
El parámetro es opcional, por lo que todo el código existente que llama `getRamUsage()` sin argumentos sigue funcionando sin ninguna modificación.

## Issue relacionado
Closes #449 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [x] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde