### PR TITLE
test: agregar pruebas unitarias para GestorAlertas

### DIFF
--- a/tests/automatizados/unit/test_gestor_alertas.cpp
+++ b/tests/automatizados/unit/test_gestor_alertas.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include "alertas/gestor_alertas.hpp"
+#include "alertas/alerta_umbral.hpp"
+#include "core/MetricSnapshot.hpp"
+
+using namespace pulso;
+using namespace pulso::alertas;
+
+TEST(GestorAlertasTest, CallbackSeLlamaCuandoAlertaSeDispara)
+{
+    GestorAlertas gestor;
+
+    int llamadas = 0;
+
+    gestor.setCallback([&](const std::string&) {
+        llamadas++;
+    });
+
+    gestor.addAlerta(AlertaUmbral("cpu", 50, '>'));
+
+    MetricSnapshot snap(80, 10, 10, 10, 10);
+
+    gestor.evaluar(snap);
+
+    EXPECT_EQ(llamadas, 1);
+}
+
+TEST(GestorAlertasTest, CallbackNoSeLlamaCuandoNoSeDisparaAlerta)
+{
+    GestorAlertas gestor;
+
+    int llamadas = 0;
+
+    gestor.setCallback([&](const std::string&) {
+        llamadas++;
+    });
+
+    gestor.addAlerta(AlertaUmbral("cpu", 90, '>'));
+
+    MetricSnapshot snap(50, 10, 10, 10, 10);
+
+    gestor.evaluar(snap);
+
+    EXPECT_EQ(llamadas, 0);
+}
+
+TEST(GestorAlertasTest, DosAlertasActivasLlamanDosVeces)
+{
+    GestorAlertas gestor;
+
+    int llamadas = 0;
+
+    gestor.setCallback([&](const std::string&) {
+        llamadas++;
+    });
+
+    gestor.addAlerta(AlertaUmbral("cpu", 50, '>'));
+    gestor.addAlerta(AlertaUmbral("ram", 50, '>'));
+
+    MetricSnapshot snap(80, 80, 10, 10, 10);
+
+    gestor.evaluar(snap);
+
+    EXPECT_EQ(llamadas, 2);
+}
+
+TEST(GestorAlertasTest, EvaluarSinAlertasNoFalla)
+{
+    GestorAlertas gestor;
+
+    gestor.setCallback([](const std::string&) {});
+
+    MetricSnapshot snap(10, 10, 10, 10, 10);
+
+    EXPECT_NO_THROW(
+        gestor.evaluar(snap);
+    );
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega pruebas unitarias para GestorAlertas utilizando Google Test.

Se incluyen pruebas para verificar:

-El callback se ejecuta cuando una alerta se dispara.
-El callback no se ejecuta cuando ninguna alerta se dispara.
-Con dos alertas activas el callback se ejecuta dos veces.
-Evaluar un gestor sin alertas registradas no produce errores.

## Issue relacionado
Closes #317

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Se agregaron 4 pruebas unitarias para cubrir los escenarios solicitados en el issue.