### PR TITLE
fix: alinear columnas de snapshots con types

### DIFF
--- a/src/storage/schema.cpp
+++ b/src/storage/schema.cpp
@@ -19,18 +19,10 @@ void inicializarEsquema(SQLite::Database& db) {
 
     db.exec(
         "CREATE TABLE IF NOT EXISTS snapshots ("
-        "    id                 INTEGER PRIMARY KEY AUTOINCREMENT,"
-        "    timestamp          INTEGER NOT NULL,"
-        "    cpu_usage          REAL,"
-        "    cpu_cores          INTEGER,"
-        "    memory_total       INTEGER,"
-        "    memory_used        INTEGER,"
-        "    memory_available   INTEGER,"
-        "    disk_total         INTEGER,"
-        "    disk_used          INTEGER,"
-        "    disk_free          INTEGER,"
-        "    network_rx_bytes   INTEGER,"
-        "    network_tx_bytes   INTEGER"
+        "    timestamp INTEGER NOT NULL,"
+        "    nombre    TEXT    NOT NULL,"
+        "    valor     REAL    NOT NULL,"
+        "    unidad    TEXT    NOT NULL"
         ");"
     );
 


### PR DESCRIPTION
## ¿Qué hace este PR?

Corrige el esquema de la tabla `snapshots` en `src/storage/schema.cpp` para que las columnas del `CREATE TABLE` coincidan con los campos definidos en `types.hpp`.

Se reemplazaron columnas específicas que no forman parte del contrato actual, como `cpu_usage`, `memory_total`, `disk_total` y `network_rx_bytes`, por columnas alineadas con `Snapshot` y `Metrica`:

* `timestamp` → `std::int64_t` → `INTEGER`
* `nombre` → `std::string` → `TEXT`
* `valor` → `double` → `REAL`
* `unidad` → `std::string` → `TEXT`

Se mantiene la idempotencia con `CREATE TABLE IF NOT EXISTS`.

No se eliminó ni modificó el índice `idx_snapshots_timestamp`.

## Issue relacionado

Closes #217 

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [x] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

