### PR TITLE
test: add FormatterJSON unit tests

### DIFF
--- a/tests/automatizados/unit/test_formatter_json.cpp
+++ b/tests/automatizados/unit/test_formatter_json.cpp
@@ -1,0 +1,99 @@
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "core/types.hpp"
+#include "formatters/formatter_json.hpp"
+
+namespace {
+
+pulso::core::Snapshot crearSnapshotConocido()
+{
+    pulso::core::Snapshot snapshot;
+
+    snapshot.timestamp = 1710000000;
+
+    snapshot.metricas = {
+        {"cpu", 42.5, "porcentaje", 1710000000},
+        {"memory", 68.0, "porcentaje", 1710000000},
+        {"disk", 71.3, "porcentaje", 1710000000},
+        {"network", 2048.0, "bytes", 1710000000}
+    };
+
+    return snapshot;
+}
+
+bool llavesBalanceadas(const std::string& texto)
+{
+    int balance = 0;
+
+    for (char c : texto) {
+        if (c == '{') {
+            ++balance;
+        } else if (c == '}') {
+            --balance;
+
+            if (balance < 0) {
+                return false;
+            }
+        }
+    }
+
+    return balance == 0;
+}
+
+} // namespace
+
+TEST(FormatterJSONTest, ResultadoNoEsVacio)
+{
+    pulso::core::Snapshot snapshot = crearSnapshotConocido();
+    pulso::formatters::FormatterJSON formatter;
+
+    const std::string resultado = formatter.formatear(snapshot);
+
+    EXPECT_FALSE(resultado.empty());
+}
+
+TEST(FormatterJSONTest, ContieneCpu)
+{
+    pulso::core::Snapshot snapshot = crearSnapshotConocido();
+    pulso::formatters::FormatterJSON formatter;
+
+    const std::string resultado = formatter.formatear(snapshot);
+
+    EXPECT_NE(resultado.find("cpu"), std::string::npos);
+}
+
+TEST(FormatterJSONTest, ContieneTimestamp)
+{
+    pulso::core::Snapshot snapshot = crearSnapshotConocido();
+    pulso::formatters::FormatterJSON formatter;
+
+    const std::string resultado = formatter.formatear(snapshot);
+
+    EXPECT_NE(resultado.find("timestamp"), std::string::npos);
+}
+
+TEST(FormatterJSONTest, ContieneCamposRequeridos)
+{
+    pulso::core::Snapshot snapshot = crearSnapshotConocido();
+    pulso::formatters::FormatterJSON formatter;
+
+    const std::string resultado = formatter.formatear(snapshot);
+
+    EXPECT_NE(resultado.find("cpu"), std::string::npos);
+    EXPECT_NE(resultado.find("memory"), std::string::npos);
+    EXPECT_NE(resultado.find("disk"), std::string::npos);
+    EXPECT_NE(resultado.find("network"), std::string::npos);
+    EXPECT_NE(resultado.find("timestamp"), std::string::npos);
+}
+
+TEST(FormatterJSONTest, LlavesEstanBalanceadas)
+{
+    pulso::core::Snapshot snapshot = crearSnapshotConocido();
+    pulso::formatters::FormatterJSON formatter;
+
+    const std::string resultado = formatter.formatear(snapshot);
+
+    EXPECT_TRUE(llavesBalanceadas(resultado));
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo tests/automatizados/unit/test_formatter_json.cpp con pruebas unitarias para FormatterJSON.

Los tests construyen un snapshot con valores conocidos, llaman al formateador JSON y verifican que:

- El resultado no esté vacío.
- El JSON contenga cpu.
-  El JSON contenga timestamp.
- El JSON contenga los campos requeridos cpu, memory, disk, network y timestamp.
- Las llaves {} estén balanceadas.

## Issue relacionado
Closes #321 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas