### PR TITLE
chore: agregar .github/CODEOWNERS con revisores por modulo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Regla * como fallback para cualquier archivo no listado abajo
+* @erwinsaul
+
+# Reglas específicas por módulo usando el formato /directorio/ @usuario
+/src/collectors/* @LinoSimon20 @Alex-Calle-P @Vizalla @YORDY-SG
+/src/http/* @Alex-Calle-P @Vizalla @YORDY-SG @LinoSimon20
+/src/formatters/* @Vizalla @YORDY-SG @LinoSimon20 @Alex-Calle-P
+/docs/* @YORDY-SG @LinoSimon20 @Alex-Calle-P @Vizalla


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el archivo de configuración `.github/CODEOWNERS` en la raíz del repositorio para automatizar la asignación de revisores en los Pull Requests según los directorios modificados. Se implementó una estrategia de responsabilidad compartida donde todos los desarrolladores activos participan como revisores en los distintos módulos, priorizando el orden de revisión por área y manteniendo un fallback global hacia el administrador del proyecto.

## Cambios
- **Nuevo archivo:** `.github/CODEOWNERS` estructurado con reglas específicas para las rutas de colectores, HTTP, formateadores y documentación.

## Issue relacionado
Closes #315

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
El archivo `.github/CODEOWNERS` fue creado localmente con la sintaxis exacta de cuentas de GitHub verificadas en el historial del proyecto:
<img width="650" height="198" alt="image" src="https://github.com/user-attachments/assets/1f24e821-b986-46aa-ab6f-58dfc632e8c8" />
