### PR TITLE
feat(storage): agregar rotacion automatica de snapshots

### DIFF
--- a/src/storage/storage.cpp
+++ b/src/storage/storage.cpp
@@ -7,6 +7,38 @@
 
 namespace pulso::storage {
 
+namespace {
+
+void pruneSnapshots(SQLite::Database& db, std::size_t maxEntries) {
+    SQLite::Statement countQuery(db, "SELECT COUNT(*) FROM snapshots;");
+    countQuery.executeStep();
+
+    const auto total = static_cast<std::size_t>(
+        countQuery.getColumn(0).getInt64()
+    );
+
+    if (total <= maxEntries) {
+        return;
+    }
+
+    const auto toDelete = static_cast<std::int64_t>(total - maxEntries);
+
+    SQLite::Statement deleteQuery(
+        db,
+        "DELETE FROM snapshots "
+        "WHERE rowid IN ("
+        "SELECT rowid FROM snapshots "
+        "ORDER BY timestamp ASC, rowid ASC "
+        "LIMIT ?"
+        ");"
+    );
+
+    deleteQuery.bind(1, toDelete);
+    deleteQuery.exec();
+}
+
+} // namespace
+
 Storage::Storage(const std::string& dbPath)
     : db_(dbPath, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE)
 {
@@ -15,6 +47,11 @@ Storage::Storage(const std::string& dbPath)
 
     // Inicializar esquema (idempotente)
     pulso::storage::inicializarEsquema(db_);
+}
+
+void Storage::setMaxEntries(std::size_t max) {
+    maxEntries_ = max;
+    pruneSnapshots(db_, maxEntries_);
 }
 
 void Storage::exportToCSV(const std::string& ruta_archivo) const {
@@ -99,6 +136,8 @@ void Storage::save(const pulso::core::Snapshot& snapshot) {
     query.bind(11, static_cast<int64_t>(getMetricValue("network.tx_bytes")));
 
     query.exec();
+
+    pruneSnapshots(db_, maxEntries_);
 }
 
 // Convierte una fila de la query en un Snapshot

--- a/src/storage/storage.hpp
+++ b/src/storage/storage.hpp
@@ -1,5 +1,5 @@
 #pragma once
- 
+
 #include <string>
 #include <vector>
 #include <optional>
@@ -7,9 +7,9 @@
 #include <cstddef>
 #include <SQLiteCpp/SQLiteCpp.h>
 #include "../core/types.hpp"
- 
+
 namespace pulso::storage {
- 
+
 /**
  * @brief Encapsula todas las operaciones de persistencia contra la base de datos SQLite.
  *
@@ -27,19 +27,31 @@ public:
      * @throws ErrorStorage si la apertura falla.
      */
     explicit Storage(const std::string& dbPath);
- 
+
     /**
      * @brief Inserta un snapshot en la base de datos.
      * @param snapshot Snapshot a persistir.
      */
     void save(const pulso::core::Snapshot& snapshot);
- 
+
+    /**
+     * @brief Configura el número máximo de snapshots retenidos.
+     *
+     * Cuando se agrega un nuevo snapshot y se supera este límite,
+     * se descarta el snapshot más antiguo siguiendo una política FIFO.
+     *
+     * El límite por defecto es 3600 entradas.
+     *
+     * @param max Cantidad máxima de snapshots a conservar.
+     */
+    void setMaxEntries(std::size_t max);
+
     /**
      * @brief Devuelve el snapshot más reciente almacenado.
      * @return El snapshot más reciente, o std::nullopt si no hay datos.
      */
     std::optional<pulso::core::Snapshot> last() const;
- 
+
     /**
      * @brief Devuelve snapshots en el rango de timestamps indicado.
      *
@@ -52,7 +64,7 @@ public:
         std::int64_t from,
         std::int64_t until = 0,
         std::size_t  limit = 1000) const;
- 
+
     /**
      * @brief Cuenta el total de snapshots almacenados en la base de datos.
      * @return Cantidad total de snapshots.
@@ -76,9 +88,10 @@ public:
      * @return Snapshot con los valores promediados.
      */
     pulso::core::Snapshot getPromedio(uint32_t ventana_segundos) const;
- 
+
 private:
     SQLite::Database db_;
+    std::size_t maxEntries_ = 3600;
 };
- 
+
 } // namespace pulso::storage


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa una política de retención automática para los snapshots almacenados por `Storage`.

Se agrega el método `setMaxEntries(size_t max)`, que permite configurar la cantidad máxima de snapshots retenidos. Cuando se inserta un nuevo snapshot y se supera el límite definido, se elimina automáticamente la entrada más antigua siguiendo una política FIFO.

También se define un límite por defecto de `3600` entradas, equivalente a aproximadamente 1 hora si se guarda 1 snapshot por segundo.

## Issue relacionado

Closes #293 

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [x] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas
