### PR TITLE
chore: add ASAN option for test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Criterio de aceptación: Desactivado (OFF) por defecto para compilaciones limpias
 option(BUILD_TESTS "Build tests" OFF)
 option(PULSO_BUILD_TESTS "Build tests (Legacy)" OFF)
+option(BUILD_WITH_ASAN "Build tests with AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
 # Si el usuario activa cualquiera de las dos opciones, sincronizamos el estado
 if(BUILD_TESTS OR PULSO_BUILD_TESTS)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,31 @@
 enable_testing()
 message(STATUS "Tests are enabled (PULSO_BUILD_TESTS=ON)")
+
 find_package(GTest REQUIRED)
 include(GoogleTest)
+
+if(BUILD_WITH_ASAN)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        message(STATUS "Building tests with AddressSanitizer and UndefinedBehaviorSanitizer")
+
+        add_library(pulso_test_sanitizers INTERFACE)
+        target_compile_options(pulso_test_sanitizers INTERFACE
+            -fsanitize=address,undefined
+            -fno-omit-frame-pointer
+        )
+        target_link_options(pulso_test_sanitizers INTERFACE
+            -fsanitize=address,undefined
+        )
+    else()
+        message(FATAL_ERROR "BUILD_WITH_ASAN requires GCC or Clang")
+    endif()
+endif()
+
+function(pulso_enable_asan_for_test target_name)
+    if(BUILD_WITH_ASAN)
+        target_link_libraries(${target_name} PRIVATE pulso_test_sanitizers)
+    endif()
+endfunction()
 
 add_executable(test_types
     core/test_types.cpp
@@ -13,8 +37,9 @@ target_link_libraries(test_types PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
+pulso_enable_asan_for_test(test_types)
 gtest_discover_tests(test_types)
- 
+
 add_executable(test_config
     test_config.cpp
 )
@@ -25,6 +50,7 @@ target_link_libraries(test_config PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
+pulso_enable_asan_for_test(test_config)
 gtest_discover_tests(test_config)
 
 add_executable(test_storage
@@ -41,7 +67,9 @@ target_link_libraries(test_storage PRIVATE
     pthread
     dl
 )
+pulso_enable_asan_for_test(test_storage)
 gtest_discover_tests(test_storage)
+
 add_executable(test_disk_usage
     automatizados/test_disk_usage.cpp
 )
@@ -52,7 +80,9 @@ target_link_libraries(test_disk_usage PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
+pulso_enable_asan_for_test(test_disk_usage)
 gtest_discover_tests(test_disk_usage)
+
 add_executable(test_formatter_prometheus
     formatters/test_formatter_prometheus.cpp
     ${PROJECT_SOURCE_DIR}/src/formatters/formatter_prometheus.cpp
@@ -64,4 +94,5 @@ target_link_libraries(test_formatter_prometheus PRIVATE
     GTest::gtest
     GTest::gtest_main
 )
+pulso_enable_asan_for_test(test_formatter_prometheus)
 gtest_discover_tests(test_formatter_prometheus)


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega la opción BUILD_WITH_ASAN en CMake para permitir compilar los tests con AddressSanitizer y UndefinedBehaviorSanitizer durante el desarrollo.

Cuando BUILD_WITH_ASAN=ON, los ejecutables de tests se compilan con los flags:

-fsanitize=address,undefined
-fno-omit-frame-pointer

La opción queda desactivada por defecto, por lo que el build normal de producción no usa ASAN.

## Issue relacionado
Closes #319 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas