### PR TITLE
chore: configurar valgrind en CI para deteccion de memory leaks en tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,10 @@ jobs:
           xargs clang-tidy --config-file=.clang-tidy --warnings-as-errors='' -- -std=c++17
       - name: Ejecutar tests con ctest
         run: cd build && ctest --output-on-failure
+      - name: Ejecutar detección de memory leaks con Valgrind
+        if: runner.os == 'Linux'
+        continue-on-error: true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+          valgrind --leak-check=full --error-exitcode=1 ./build/tests/pulso_tests


### PR DESCRIPTION
## ¿Qué hace este PR?
Integra un paso (*step*) automatizado en el flujo de integración continua (`ci.yml`) para ejecutar **Valgrind** sobre el binario de pruebas `./build/tests/pulso_tests`. Esto permite la detección temprana de fugas de memoria (*memory leaks*) en entornos Linux, configurado con `continue-on-error: true` para reportar los análisis exhaustivos sin interrumpir de manera crítica el flujo de los Pull Requests existentes.

## Cambios
- **Modificación:** `.github/workflows/ci.yml` añadiendo el step para instalar y ejecutar Valgrind con los flags `--leak-check=full` y `--error-exitcode=1`.

## Issue relacionado
Closes #316

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1139" height="603" alt="image" src="https://github.com/user-attachments/assets/d37acb3e-453f-45b5-b75c-0f60dfe29005" />
<img width="656" height="146" alt="image" src="https://github.com/user-attachments/assets/afc2b537-19b6-4db0-9b0e-c6bc1b01d214" />
