### PR TITLE
fix(cmake): registrar handler_metrics.cpp en target_sources — habilitar compilación del endpoint GET /metrics

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ target_sources(pulso PRIVATE
     formatters/formatter_prometheus.cpp
     http/handler_health.cpp
     http/handler_history.cpp
+    http/handler_metrics.cpp
     collectors/loadavg/loadavg_collector.cpp
     collectors/procesos/proc_collector.cpp
     platform/linux/collector_cpu.cpp


### PR DESCRIPTION
## ¿Qué hace este PR?
Registra `http/handler_metrics.cpp` en `target_sources` dentro de `src/CMakeLists.txt` para que el archivo sea compilado junto con el resto del proyecto.

## Contexto
`handler_metrics.cpp` fue creado como parte del issue #270, pero no fue registrado en `target_sources`. Esto impedía que el archivo fuera incluido en el build.

## Issue relacionado
Closes #404

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Archivos modificados
- `src/CMakeLists.txt`

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas