### PR TITLE
chore: configurar AddressSanitizer en el build de tests para detectar errores de memoria en desarrollo- #319

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Criterio de aceptación: Desactivado (OFF) por defecto para compilaciones limpias
 option(BUILD_TESTS "Build tests" OFF)
 option(PULSO_BUILD_TESTS "Build tests (Legacy)" OFF)
+option(BUILD_WITH_ASAN "Build tests with AddressSanitizer" OFF)
 
 # Si el usuario activa cualquiera de las dos opciones, sincronizamos el estado
 if(BUILD_TESTS OR PULSO_BUILD_TESTS)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,37 @@ Para una guía completa de instalación consulte:
 
 ---
 
+## Compilación con AddressSanitizer
+
+AddressSanitizer (ASAN) es una herramienta para detectar errores de memoria como accesos inválidos, leaks de memoria, y otros problemas. Es más rápido que Valgrind y ideal para desarrollo.
+
+### Compilar tests con ASAN
+
+```bash
+cmake -S . -B build -DBUILD_TESTS=ON -DBUILD_WITH_ASAN=ON
+cmake --build build
+```
+
+### Ejecutar tests con ASAN
+
+```bash
+cd build
+ctest
+```
+
+O ejecutar un test específico:
+
+```bash
+./build/bin/test_types
+./build/bin/test_config
+./build/bin/test_storage
+```
+
+> [!NOTE]
+> AddressSanitizer solo se aplica a los tests. El build de producción no incluye los flags de ASAN para mantener el rendimiento.
+
+---
+
 ## Ejemplo de salida
 
 Ejecutar:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,14 @@ message(STATUS "Tests are enabled (PULSO_BUILD_TESTS=ON)")
 find_package(GTest REQUIRED)
 include(GoogleTest)
 
+# Apply AddressSanitizer flags if BUILD_WITH_ASAN is enabled
+if(BUILD_WITH_ASAN)
+    message(STATUS "Building tests with AddressSanitizer enabled")
+    set(ASAN_FLAGS "-fsanitize=address,undefined -fno-omit-frame-pointer")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ASAN_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_FLAGS}")
+endif()
+
 add_executable(test_types
     core/test_types.cpp
 )


### PR DESCRIPTION
## ¿Qué hace este PR?
Esta PR configura AddressSanitizer (ASAN) en el build de tests para detectar errores de memoria durante el desarrollo. ASAN es más rápido que Valgrind y permite identificar accesos inválidos a memoria, leaks y otros problemas.

## Issue relacionado
Closes #319 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="480" height="66" alt="image" src="https://github.com/user-attachments/assets/c4e017b6-3fd8-4930-898a-1067e99e2e54" />
