### PR TITLE
chore(tests): register ram usage test executable

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -65,3 +65,16 @@ target_link_libraries(test_formatter_prometheus PRIVATE
     GTest::gtest_main
 )
 gtest_discover_tests(test_formatter_prometheus)
+
+add_executable(test_ram_usage
+    automatizados/test_ram_usage.cpp
+    ${PROJECT_SOURCE_DIR}/src/collectors/memory/ram_usage.cpp
+)
+target_include_directories(test_ram_usage PRIVATE
+    ${PROJECT_SOURCE_DIR}/src
+)
+target_link_libraries(test_ram_usage PRIVATE
+    GTest::gtest
+    GTest::gtest_main
+)
+gtest_discover_tests(test_ram_usage)


### PR DESCRIPTION
## ¿Qué hace este PR?
Registra el ejecutable test_ram_usage en tests/CMakeLists.txt para que el test automatizado tests/automatizados/test_ram_usage.cpp pueda ser descubierto y ejecutado por ctest.

## Issue relacionado
Closes #450 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas