### PR TITLE
chore(cmake): register temperatura collector source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,9 @@ target_sources(pulso PRIVATE
     collectors/memory/ram_usage.cpp
     collectors/network/network_io.cpp
     collectors/network/net_usage.cpp
+    collectors/loadavg/loadavg_collector.cpp
+    collectors/procesos/proc_collector.cpp
+    collectors/temperatura/temp_collector.cpp
     config/config.cpp
     core/SystemMonitor.cpp
     formatters/formatter_json.cpp
@@ -14,8 +17,6 @@ target_sources(pulso PRIVATE
     http/handler_health.cpp
     http/handler_history.cpp
     http/handler_metrics.cpp
-    collectors/loadavg/loadavg_collector.cpp
-    collectors/procesos/proc_collector.cpp
     platform/linux/collector_cpu.cpp
     sampler/sampler.cpp
     storage/schema.cpp


### PR DESCRIPTION
## ¿Qué hace este PR?
Registra collectors/temperatura/temp_collector.cpp dentro de target_sources(pulso PRIVATE ...) en src/CMakeLists.txt, para que el collector de temperatura quede integrado al build del proyecto.

## Issue relacionado
Closes #405 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas